### PR TITLE
Add AES-CBC fallback for SecureStore compatibility

### DIFF
--- a/Get-SecureStoreList.ps1
+++ b/Get-SecureStoreList.ps1
@@ -1,58 +1,82 @@
-﻿function Get-SecureStoreList {
+function Get-SecureStoreList {
     [CmdletBinding()]
+    [OutputType([pscustomobject])]
     param(
-        [Parameter(Mandatory = $false)]
-        [string]$FolderPath = "C:\SecureStore"
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]$FolderPath = $script:DefaultSecureStorePath,
+
+        [Parameter()]
+        [ValidateRange(1, 365)]
+        [int]$ExpiryWarningDays = 30
     )
 
     begin {
-        if (-not (Get-Command "Sync-SecureStoreWorkingDirectory" -ErrorAction SilentlyContinue)) {
-            . "$PSScriptRoot\Sync-SecureStoreWorkingDirectory.ps1"
+        if (-not (Get-Command -Name 'Sync-SecureStoreWorkingDirectory' -ErrorAction SilentlyContinue)) {
+            . "$PSScriptRoot/Sync-SecureStoreWorkingDirectory.ps1"
         }
-        Sync-SecureStoreWorkingDirectory | Out-Null
     }
 
     process {
-        # Get SecureStore paths
         $paths = Sync-SecureStoreWorkingDirectory -BasePath $FolderPath
 
-        Write-Host "SecureStore inventory: $($paths.BasePath)"
+        $keyFiles = @(Get-ChildItem -LiteralPath $paths.BinPath -Filter '*.bin' -File -ErrorAction SilentlyContinue)
+        $secretFiles = @(Get-ChildItem -LiteralPath $paths.SecretPath -File -ErrorAction SilentlyContinue)
+        $certFiles = @(Get-ChildItem -LiteralPath $paths.CertsPath -File -ErrorAction SilentlyContinue)
 
-        # Check keys
-        $keyFiles = Get-ChildItem -Path $paths.BinPath -Filter "*.bin" -ErrorAction SilentlyContinue
-        Write-Host "Keys ($($keyFiles.Count)):"
-        if ($keyFiles) {
-            foreach ($key in $keyFiles) {
-                Write-Host "  $($key.BaseName)"
+        $certificateDetails = @()
+        foreach ($file in $certFiles) {
+            $entry = [PSCustomObject]@{
+                Name        = $file.Name
+                FullName    = $file.FullName
+                Thumbprint  = $null
+                NotAfter    = $null
+                ExpiresSoon = $false
             }
-        } else {
-            Write-Host "  (none)"
+
+            $certificate = $null
+            try {
+                switch ($file.Extension.ToLowerInvariant()) {
+                    '.pem' {
+                        $content = Read-SecureStoreText -Path $file.FullName -Encoding ([System.Text.Encoding]::ASCII)
+                        $base64 = ($content -replace '-----BEGIN CERTIFICATE-----', '' -replace '-----END CERTIFICATE-----', '' -replace '\s', '')
+                        if (-not [string]::IsNullOrWhiteSpace($base64)) {
+                            $raw = [Convert]::FromBase64String($base64)
+                            $certificate = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($raw)
+                        }
+                    }
+                    '.cer' { $certificate = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($file.FullName) }
+                    '.crt' { $certificate = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($file.FullName) }
+                    '.der' { $certificate = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($file.FullName) }
+                    default { }
+                }
+
+                if ($certificate) {
+                    $entry.Thumbprint = $certificate.Thumbprint
+                    $entry.NotAfter = $certificate.NotAfter
+                    if ($certificate.NotAfter -le (Get-Date).AddDays($ExpiryWarningDays)) {
+                        $entry.ExpiresSoon = $true
+                        Write-Warning "Certificate '$($file.Name)' expires on $($certificate.NotAfter.ToString('u'))."
+                    }
+                }
+            }
+            catch {
+                Write-Verbose "Failed to parse certificate '$($file.FullName)': $($_.Exception.Message)"
+            }
+            finally {
+                if ($certificate -and ($certificate -is [System.IDisposable])) {
+                    $certificate.Dispose()
+                }
+            }
+
+            $certificateDetails += $entry
         }
 
-        # Check secrets
-        $secretFiles = Get-ChildItem -Path $paths.SecretPath -ErrorAction SilentlyContinue
-        Write-Host "Secrets ($($secretFiles.Count)):"
-        if ($secretFiles) {
-            foreach ($secret in $secretFiles) {
-                Write-Host "  $($secret.Name)"
-            }
-        } else {
-            Write-Host "  (none)"
+        [PSCustomObject]@{
+            BasePath     = $paths.BasePath
+            Keys         = $keyFiles.Name
+            Secrets      = $secretFiles.Name
+            Certificates = $certificateDetails
         }
-
-        # Check certificates
-        $certFiles = Get-ChildItem -Path $paths.CertsPath -Filter "*.*" -ErrorAction SilentlyContinue
-        Write-Host "Certificates ($($certFiles.Count)):"
-        if ($certFiles) {
-            foreach ($cert in $certFiles) {
-                Write-Host "  $($cert.Name)"
-            }
-        } else {
-            Write-Host "  (none)"
-        }
-
-        # Summary
-        $totalFiles = $keyFiles.Count + $secretFiles.Count + $certFiles.Count
-        Write-Host "Total assets: $totalFiles"
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,18 +1,28 @@
-﻿# SecureStore
+# SecureStore
 
 > Enterprise-grade PowerShell module for secure local secret management and certificate generation
 
-SecureStore provides a centralized, secure solution for managing passwords, API keys, and certificates in PowerShell environments. With AES-256 encryption and organized folder structure, it's perfect for DevOps workflows, automation scripts, and enterprise environments.
+SecureStore provides a centralized, secure solution for managing passwords, API keys, and certificates across Windows and cross-platform PowerShell environments. With authenticated AES-256 encryption, safe file handling, and an organized folder structure, it is well suited for DevOps workflows, automation scripts, and enterprise deployments.
 
 ## Key Features
 
-- **AES-256 Encryption** - Industry-standard security for all stored secrets
-- **Centralized Storage** - Organized `C:\SecureStore` structure with `bin\`, `secret\`, and `certs\` folders
-- **Certificate Generation** - Create self-signed certificates with PFX and PEM export
-- **Flexible Access** - Both name-based and direct path access methods
-- **No Cloud Dependencies** - Purely local storage with Windows file system permissions
-- **Enterprise Ready** - Built for team environments and automation workflows
-- **PowerShell 5.1+** - Compatible with Windows PowerShell and PowerShell Core
+- **AES-256 Authenticated Encryption** – AES-GCM when available, otherwise AES-CBC with HMAC-SHA256, all with per-secret PBKDF2-derived keys
+- **Centralized Storage** – Organized `bin`, `secrets`, and `certs` folders at an OS-aware default path
+- **Certificate Automation** – Create self-signed certificates with SAN/EKU support, mandatory PFX protection, and optional PEM export
+- **Flexible Access** – Both name-based and direct path access patterns
+- **Safety First** – Atomic writes, zeroized secrets, ShouldProcess support, and redacted error messages
+- **PowerShell 5.1+** – Compatible with Windows PowerShell and PowerShell 7+
+
+## Default Locations
+
+SecureStore selects a platform-specific default base folder. Override anytime with `-FolderPath`.
+
+| Platform | Default Path |
+|----------|--------------|
+| Windows  | `Join-Path $env:ProgramData 'SecureStore'` |
+| Non-Windows | `Join-Path $HOME '.securestore'` |
+
+> **Migration note:** Existing `secret` folders are still accepted but deprecated; migrate to `secrets` soon. Future major versions will remove `secret` support.
 
 ## Quick Start
 
@@ -20,237 +30,193 @@ SecureStore provides a centralized, secure solution for managing passwords, API 
 # Import the module
 Import-Module SecureStore
 
-# Test your environment
+# Inspect the environment at the default path
 Test-SecureStoreEnvironment
 
-# Create your first secret
-New-SecureStoreSecret -KeyName "Database" -SecretFileName "prod.secret" -Password "MySecurePassword123"
+# Create your first secret (WhatIf preview)
+New-SecureStoreSecret -KeyName 'Database' -SecretFileName 'prod.secret' -Password 'MySecurePassword123' -WhatIf
 
-# Retrieve the secret
-$password = Get-SecureStoreSecret -KeyName "Database" -SecretFileName "prod.secret"
+# Persist the secret after preview
+New-SecureStoreSecret -KeyName 'Database' -SecretFileName 'prod.secret' -Password 'MySecurePassword123'
 
-# Create a certificate
-New-SecureStoreCertificate -CertificateName "MyApp" -Password "CertPassword123"
+# Retrieve the secret as plain text
+$password = Get-SecureStoreSecret -KeyName 'Database' -SecretFileName 'prod.secret'
 
-# List all your assets
-Get-SecureStoreList
+# Generate a certificate with confirmation bypass
+New-SecureStoreCertificate -CertificateName 'MyApp' -Password 'CertPassword123' -Confirm:$false
+
+# List all stored assets
+Get-SecureStoreList | Format-List
 ```
 
 ## Installation
 
-### Method 1: Manual Installation
-1. Download the latest release or clone this repository
-2. Extract/copy all files to: `C:\Program Files\WindowsPowerShell\Modules\SecureStore\`
-3. Import the module: `Import-Module SecureStore`
-4. Verify installation: `Test-SecureStoreEnvironment`
+### Manual Installation
+1. Download the latest release or clone this repository.
+2. Copy the files to your module path, e.g. `C:\Program Files\WindowsPowerShell\Modules\SecureStore\` or `$HOME/.local/share/powershell/Modules/SecureStore`.
+3. Import the module: `Import-Module SecureStore`.
+4. Verify installation: `Test-SecureStoreEnvironment`.
 
-### Method 2: Using the Zip Creator
-1. Run the included `Create-SecureStoreZip.ps1` script
-2. Extract `SecureStore.zip` to your PowerShell modules directory
-3. Import and test as above
+### Zip Creator
+1. Run the included `Create-SecureStoreZip.ps1` script.
+2. Extract `SecureStore.zip` to a module directory.
+3. Import and test as above.
 
 ## Folder Structure
 
-SecureStore creates a standardized folder structure for all your security assets:
+SecureStore maintains a consistent structure for keys, encrypted secrets, and certificates.
 
 ```
-C:\SecureStore\
-├── bin\                    # AES encryption keys (.bin files)
+<SecureStore base>
+├── bin\                    # AES master keys (.bin files)
 │   ├── Database.bin
 │   ├── API.bin
 │   └── MyApp.bin
-├── secrets\                 # Encrypted secrets (any filename)
+├── secrets\                # Encrypted secrets (any filename)
 │   ├── prod.secret
 │   ├── api-key.secret
 │   └── config.secret
-└── certs\                  # Certificates (.pfx and .pem files)
+└── certs\                  # Certificates (.pfx, optional .pem)
     ├── MyApp.pfx
     ├── MyApp.pem
     ├── WebServer.pfx
     └── WebServer.pem
 ```
 
-## Functions Reference
-
-### `New-SecureStoreSecret`
-Creates an encrypted secret with a local encryption key.
+Use `-FolderPath` to target alternate roots:
 
 ```powershell
-# Basic usage (creates in C:\SecureStore)
-New-SecureStoreSecret -KeyName "MyApp" -SecretFileName "database.secret" -Password "MyPassword123"
+New-SecureStoreSecret -KeyName 'API' -SecretFileName 'token.secret' -Password 'PlainText' -FolderPath '/srv/app/secrets'
+Get-SecureStoreList   -FolderPath '/srv/app/secrets'
+```
 
-# Custom location
-New-SecureStoreSecret -KeyName "API" -SecretFileName "token.secret" -Password "api-token-xyz" -FolderPath "D:\MySecrets"
+## Function Reference
+
+### `New-SecureStoreSecret`
+Creates an encrypted secret using authenticated AES-256 encryption and atomic file writes.
+
+```powershell
+# Store secret with automatic SecureString conversion
+New-SecureStoreSecret -KeyName 'MyApp' -SecretFileName 'database.secret' -Password 'MyPassword123'
+
+# Provide a SecureString explicitly
+$secure = Read-Host 'Enter secret' -AsSecureString
+New-SecureStoreSecret -KeyName 'MyApp' -SecretFileName 'database.secret' -Password $secure -Confirm:$false
+
+# Preview folder changes without writing
+New-SecureStoreSecret -KeyName 'Preview' -SecretFileName 'test.secret' -Password 'demo' -WhatIf
 ```
 
 ### `Get-SecureStoreSecret`
-Retrieves and decrypts a stored secret.
+Retrieves and decrypts stored secrets as plain text or credentials.
 
 ```powershell
-# Get as plain text
-$password = Get-SecureStoreSecret -KeyName "MyApp" -SecretFileName "database.secret"
+# Get plain text
+$password = Get-SecureStoreSecret -KeyName 'MyApp' -SecretFileName 'database.secret'
 
-# Get as PSCredential object
-$cred = Get-SecureStoreSecret -KeyName "MyApp" -SecretFileName "database.secret" -AsCredential
+# Get PSCredential with custom username
+$cred = Get-SecureStoreSecret -KeyName 'MyApp' -SecretFileName 'database.secret' -AsCredential -UserName 'db-user'
 
-# Direct path access
-$password = Get-SecureStoreSecret -KeyPath ".\bin\MyApp.bin" -SecretPath ".\secret\database.secret"
+# Direct path access (use the secrets folder)
+$password = Get-SecureStoreSecret -KeyPath './bin/MyApp.bin' -SecretPath './secrets/database.secret'
 ```
 
 ### `New-SecureStoreCertificate`
-Creates self-signed certificates with PFX and PEM export.
+Generates self-signed certificates with RSA 3072 or ECDSA curves, SAN/EKU support, and secure exports.
 
 ```powershell
-# Basic certificate (2-year validity)
-New-SecureStoreCertificate -CertificateName "MyApp" -Password "CertPass123"
+# Basic certificate (1-year validity)
+New-SecureStoreCertificate -CertificateName 'MyApp' -Password 'CertPass123'
 
-# Custom validity and subject
-New-SecureStoreCertificate -CertificateName "WebServer" -Password "Pass123" -ValidityYears 5 -Subject "CN=myapp.local, O=My Company"
+# Custom subject, SANs, EKUs, and PEM export
+New-SecureStoreCertificate `
+    -CertificateName 'WebServer' `
+    -Password (Read-Host 'PFX password' -AsSecureString) `
+    -ValidityYears 3 `
+    -Subject 'CN=web.internal, O=My Company' `
+    -DnsName 'web.internal','api.internal' `
+    -EnhancedKeyUsage '1.3.6.1.5.5.7.3.1','1.3.6.1.5.5.7.3.2' `
+    -ExportPem `
+    -Confirm:$false
 ```
 
 ### `Get-SecureStoreList`
-Lists all available secrets and certificates.
+Summarizes stored keys, secrets, and certificates, warning about near-expiry certificates.
 
 ```powershell
-# List default location
 Get-SecureStoreList
-
-# List custom location
-Get-SecureStoreList -FolderPath "D:\MySecrets"
+Get-SecureStoreList -FolderPath '/srv/app/secrets' -ExpiryWarningDays 45
 ```
 
 ### `Test-SecureStoreEnvironment`
-Tests environment and validates folder structure.
+Validates directory synchronization and folder readiness.
 
 ```powershell
-# Test default location
 Test-SecureStoreEnvironment
-
-# Test custom location  
-Test-SecureStoreEnvironment -FolderPath "D:\MySecrets"
+Test-SecureStoreEnvironment -FolderPath '/srv/app/secrets'
 ```
 
-## Usage Examples
+## Usage Scenarios
 
 ### Database Connection
 ```powershell
-# Store database password
-New-SecureStoreSecret -KeyName "ProdDB" -SecretFileName "connection.secret" -Password "MyDbPassword123"
-
-# Use in connection string
-$dbPassword = Get-SecureStoreSecret -KeyName "ProdDB" -SecretFileName "connection.secret"
-$connectionString = "Server=prod-server;Database=myapp;User=admin;Password=$dbPassword;Encrypt=true"
+New-SecureStoreSecret -KeyName 'ProdDB' -SecretFileName 'connection.secret' -Password (Read-Host 'DB Password' -AsSecureString)
+$connectionSecret = Get-SecureStoreSecret -KeyName 'ProdDB' -SecretFileName 'connection.secret'
+$connectionString = "Server=prod;Database=myapp;User=admin;Password=$connectionSecret;Encrypt=true"
 ```
 
 ### API Authentication
 ```powershell
-# Store API key
-New-SecureStoreSecret -KeyName "OpenAI" -SecretFileName "api-key.secret" -Password "sk-1234567890abcdef"
-
-# Use in REST calls
-$apiKey = Get-SecureStoreSecret -KeyName "OpenAI" -SecretFileName "api-key.secret"
-$headers = @{ "Authorization" = "Bearer $apiKey" }
-Invoke-RestMethod -Uri "https://api.openai.com/v1/models" -Headers $headers
+New-SecureStoreSecret -KeyName 'OpenAI' -SecretFileName 'api-key.secret' -Password 'sk-1234567890abcdef'
+$apiKey = Get-SecureStoreSecret -KeyName 'OpenAI' -SecretFileName 'api-key.secret'
+$headers = @{ Authorization = "Bearer $apiKey" }
+Invoke-RestMethod -Uri 'https://api.openai.com/v1/models' -Headers $headers
 ```
 
 ### Remote PowerShell
 ```powershell
-# Store admin credentials
-New-SecureStoreSecret -KeyName "ServerAdmin" -SecretFileName "admin.secret" -Password "AdminPassword123"
-
-# Use for remote sessions
-$adminCred = Get-SecureStoreSecret -KeyName "ServerAdmin" -SecretFileName "admin.secret" -AsCredential
-Invoke-Command -ComputerName "server01" -Credential $adminCred -ScriptBlock {
-    Get-Service | Where-Object Status -eq "Stopped"
+New-SecureStoreSecret -KeyName 'ServerAdmin' -SecretFileName 'admin.secret' -Password (Read-Host 'Admin Password' -AsSecureString)
+$adminCred = Get-SecureStoreSecret -KeyName 'ServerAdmin' -SecretFileName 'admin.secret' -AsCredential -UserName 'admin'
+Invoke-Command -ComputerName 'server01' -Credential $adminCred -ScriptBlock {
+    Get-Service | Where-Object Status -eq 'Stopped'
 }
 ```
 
-### Certificate for HTTPS
+### Certificates for HTTPS
 ```powershell
-# Create certificate for web application
-New-SecureStoreCertificate -CertificateName "WebApp" -Password "CertPass123" -Subject "CN=myapp.local"
-
-# Import to IIS (requires Administrator)
-$certPath = "C:\SecureStore\certs\WebApp.pfx"
-$certPassword = ConvertTo-SecureString "CertPass123" -AsPlainText -Force
-Import-PfxCertificate -FilePath $certPath -CertStoreLocation Cert:\LocalMachine\My -Password $certPassword
+New-SecureStoreCertificate -CertificateName 'WebApp' -Password (Read-Host 'PFX password' -AsSecureString) -Subject 'CN=myapp.local'
+$certPath = (Join-Path (Get-SecureStoreList).BasePath 'certs/WebApp.pfx')
+Import-PfxCertificate -FilePath $certPath -CertStoreLocation Cert:\LocalMachine\My -Password (Read-Host 'PFX password' -AsSecureString)
 ```
 
 ## Security Features
 
-- **AES-256 Encryption**: Uses PowerShell's built-in `ConvertFrom-SecureString` with 256-bit keys
-- **Cryptographically Secure Keys**: Generated using `RNGCryptoServiceProvider`
-- **Memory Safety**: Proper cleanup of sensitive data using BSTR marshaling
-- **File System Permissions**: Leverages Windows ACLs for access control
-- **No Network Dependencies**: Everything stored locally with no cloud exposure
-- **Certificate Security**: 2048-bit RSA keys with SHA-256 signatures
+- **Authenticated Encryption**: AES-256-GCM (or AES-256-CBC + HMAC-SHA256 on down-level hosts) with per-secret nonces and integrity checks
+- **Key Derivation**: PBKDF2-SHA256 with 200k iterations and random salt for each secret
+- **Secure Secret Handling**: SecureString conversion, BSTR zeroization, and credential-safe output
+- **Safe Storage**: Atomic file writes via temporary files and forced flush before rename
+- **Cross-Platform Defaults**: OS-aware storage locations with optional overrides
+- **ShouldProcess Support**: `-WhatIf`/`-Confirm` available on mutating commands
+- **Certificate Hygiene**: Mandatory PFX passwords, SAN/EKU support, and near-expiry warnings
 
 ## Enterprise Features
 
-- **Team Environments**: Consistent folder structure across team members
-- **Backup-Friendly**: Single folder contains all security assets
-- **Automation Ready**: Perfect for CI/CD pipelines and scheduled tasks
-- **Audit Trail**: File system logs provide access tracking
-- **Scalable**: Supports unlimited keys, secrets, and certificates
-- **Version Control Safe**: Binary keys and encrypted secrets don't expose plaintext
+- **Team Friendly**: Predictable folder structure simplifies onboarding and backups
+- **Automation Ready**: Built for CI/CD pipelines with strict mocks for testing
+- **Audit Friendly**: File-system logging and sanitized error output help investigations
+- **Scalable**: Supports unlimited keys, secrets, and certificates without cloud dependencies
 
 ## Requirements
 
 - **PowerShell**: 5.1 or later (Windows PowerShell or PowerShell Core)
-- **Operating System**: Windows (uses Windows certificate store for cert generation)
-- **Permissions**: Write access to `C:\SecureStore` (or custom folder)
-- **.NET Framework**: 4.5+ (typically already installed)
+- **Certificates**: Windows certificate APIs are required for live certificate generation; tests use mocks
 
-## Best Practices
+## Testing & Quality Gates
 
-1. **Organize by Application**: Use descriptive `KeyName` values like "MyApp", "Database", "API"
-2. **Descriptive Filenames**: Use clear `SecretFileName` like "prod.secret", "api-key.secret"
-3. **Key Reuse**: One key can encrypt multiple secrets - reuse `KeyName` for related secrets
-4. **Backup Strategy**: Regularly backup the entire `C:\SecureStore` folder
-5. **Access Control**: Use Windows file permissions to restrict folder access
-6. **Certificate Passwords**: Use strong passwords for certificate protection
-7. **Regular Rotation**: Periodically create new secrets and retire old ones
+Run the included Pester tests and script analyzer before submitting changes:
 
-## Contributing
+```powershell
+Invoke-ScriptAnalyzer -Path .\SecureStore.psm1
+Invoke-Pester -Path .\tests -Output Detailed
+```
 
-Contributions are welcome! Please feel free to submit a Pull Request. For major changes, please open an issue first to discuss what you would like to change.
-
-### Development Setup
-1. Fork this repository
-2. Clone your fork: `git clone https://github.com/yourusername/SecureStore-PowerShell.git`
-3. Create a feature branch: `git checkout -b feature/amazing-feature`
-4. Make your changes and test thoroughly
-5. Commit your changes: `git commit -m 'Add amazing feature'`
-6. Push to the branch: `git push origin feature/amazing-feature`
-7. Open a Pull Request
-
-## License
-
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-## Support
-
-- **Issues**: Report bugs or request features via [GitHub Issues](https://github.com/yourusername/SecureStore-PowerShell/issues)
-- **Discussions**: Join conversations in [GitHub Discussions](https://github.com/yourusername/SecureStore-PowerShell/discussions)
-- **Documentation**: Full documentation available in the repository
-
-## Roadmap
-
-- [ ] PowerShell Gallery publication
-- [ ] Linux/macOS support (certificate generation)
-- [ ] Import/export utilities for migration
-- [ ] Advanced key derivation options
-- [ ] Integration with Azure Key Vault (optional)
-- [ ] GUI management interface
-
-## Project Stats
-
-![GitHub stars](https://img.shields.io/github/stars/yourusername/SecureStore-PowerShell?style=social)
-![GitHub forks](https://img.shields.io/github/forks/yourusername/SecureStore-PowerShell?style=social)
-![GitHub watchers](https://img.shields.io/github/watchers/yourusername/SecureStore-PowerShell?style=social)
-
----
-
-**Star this repository if SecureStore helped you secure your PowerShell environment!**
-
-**Made with care for the PowerShell community**

--- a/SecureStore.psd1
+++ b/SecureStore.psd1
@@ -7,34 +7,34 @@
     CompanyName = 'SecureStore'
     Copyright = '(c) SecureStore Module. All rights reserved.'
     Description = 'Centralized local secret management and certificate generation with standardized folder structure'
-    
+
     # Minimum PowerShell version
     PowerShellVersion = '5.1'
-    
+
     # Functions to export from this module
     FunctionsToExport = @(
         'New-SecureStoreSecret',
-        'Get-SecureStoreSecret', 
+        'Get-SecureStoreSecret',
         'Get-SecureStoreList',
         'Test-SecureStoreEnvironment',
         'New-SecureStoreCertificate'
     )
-    
+
     # Cmdlets to export from this module
     CmdletsToExport = @()
-    
+
     # Variables to export from this module
     VariablesToExport = @()
-    
+
     # Aliases to export from this module
     AliasesToExport = @()
-    
+
     # DSC resources to export from this module
     DscResourcesToExport = @()
-    
+
     # List of all modules packaged with this module
     ModuleList = @()
-    
+
     # List of all files packaged with this module
     FileList = @(
         'SecureStore.psm1',
@@ -45,30 +45,30 @@
         'Test-SecureStoreEnvironment.ps1',
         'New-SecureStoreCertificate.ps1'
     )
-    
+
     # Private data to pass to the module specified in RootModule/ModuleToProcess
     PrivateData = @{
         PSData = @{
             # Tags applied to this module for online galleries
             Tags = @('Security', 'Secrets', 'Certificates', 'Encryption', 'LocalStorage', 'AES', 'PKI')
-            
+
             # Release notes for this module
             ReleaseNotes = 'Version 2.0.0: Centralized storage, standardized folder structure, integrated certificate generation'
-            
+
             # Prerelease string for this module
             Prerelease = ''
-            
+
             # Flag to indicate whether the module requires explicit acceptance
             RequireLicenseAcceptance = $false
-            
+
             # External dependent modules
             ExternalModuleDependencies = @()
         }
     }
-    
+
     # HelpInfo URI of this module
     HelpInfoURI = ''
-    
+
     # Default prefix for commands exported from this module
     DefaultCommandPrefix = ''
 }

--- a/SecureStore.psm1
+++ b/SecureStore.psm1
@@ -1,14 +1,608 @@
 ﻿#
+Set-StrictMode -Version Latest
+
 # SecureStore Module v2.0
 # Centralized local secret management and certificate generation
-# Default location: C:\SecureStore with standardized folder structure
-#
 
-# Set module-level variables
-$script:DefaultSecureStorePath = "C:\SecureStore"
+class SecureStoreSecureStringTransformationAttribute : System.Management.Automation.ArgumentTransformationAttribute {
+    [object] Transform([System.Management.Automation.EngineIntrinsics] $engineIntrinsics, [object] $inputData) {
+        if ($null -eq $inputData) {
+            throw [System.ArgumentNullException]::new('Password')
+        }
+
+        if ($inputData -is [System.Security.SecureString]) {
+            return $inputData
+        }
+
+        if ($inputData -is [string]) {
+            if ([string]::IsNullOrWhiteSpace([string]$inputData)) {
+                throw [System.ArgumentException]::new('Password cannot be null or empty.')
+            }
+
+            $chars = ([string]$inputData).ToCharArray()
+            try {
+                $secure = New-Object System.Security.SecureString
+                foreach ($char in $chars) {
+                    $secure.AppendChar($char)
+                }
+                $secure.MakeReadOnly()
+                return $secure
+            }
+            finally {
+                [Array]::Clear($chars, 0, $chars.Length)
+            }
+        }
+
+        if ($inputData -is [System.Collections.IEnumerable] -and -not ($inputData -is [string])) {
+            $transformed = @()
+            foreach ($item in $inputData) {
+                $transformed += $this.Transform($engineIntrinsics, $item)
+            }
+            if ($transformed.Count -eq 1) {
+                return $transformed[0]
+            }
+
+            return $transformed
+        }
+
+        throw [System.ArgumentException]::new('Password must be provided as a SecureString or plain text string.')
+    }
+}
+
+$script:IsWindowsPlatform = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)
+
+function Get-SecureStoreType {
+    [CmdletBinding()]
+    [OutputType([System.Type])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$TypeName
+    )
+
+    foreach ($assembly in [System.AppDomain]::CurrentDomain.GetAssemblies()) {
+        $type = $assembly.GetType($TypeName, $false, $false)
+        if ($null -ne $type) {
+            return $type
+        }
+    }
+
+    return [System.Type]::GetType($TypeName, $false, $false)
+}
+
+function Get-SecureStoreDefaultPath {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
+
+    if ($script:IsWindowsPlatform) {
+        $programData = $env:ProgramData
+        if ([string]::IsNullOrWhiteSpace($programData)) {
+            throw "ProgramData environment variable is not set."
+        }
+
+        return [System.IO.Path]::Combine($programData, 'SecureStore')
+    }
+
+    $homePath = if (-not [string]::IsNullOrWhiteSpace($env:HOME)) { $env:HOME } else { $HOME }
+    if ([string]::IsNullOrWhiteSpace($homePath)) {
+        throw "HOME environment variable is not set."
+    }
+
+    return Join-Path -Path $homePath -ChildPath '.securestore'
+}
+
+$script:DefaultSecureStorePath = Get-SecureStoreDefaultPath
+$script:LegacySecretWarningIssued = $false
+
+$script:AesGcmType = Get-SecureStoreType -TypeName 'System.Security.Cryptography.AesGcm'
+if (-not $script:AesGcmType) {
+    try {
+        Add-Type -AssemblyName 'System.Security.Cryptography.Algorithms' -ErrorAction Stop | Out-Null
+    }
+    catch {
+        Write-Verbose "AES-GCM support unavailable: $($_.Exception.Message)"
+    }
+
+    $script:AesGcmType = Get-SecureStoreType -TypeName 'System.Security.Cryptography.AesGcm'
+}
+
+$script:SupportsAesGcm = $null -ne $script:AesGcmType
+
+function Test-SecureStoreFixedTimeEqual {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [byte[]]$Left,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [byte[]]$Right
+    )
+
+    if ($Left.Length -ne $Right.Length) {
+        return $false
+    }
+
+    $result = 0
+    for ($i = 0; $i -lt $Left.Length; $i++) {
+        $result = $result -bor ($Left[$i] -bxor $Right[$i])
+    }
+
+    return ($result -eq 0)
+}
+
+function ConvertTo-SecureStoreSecureString {
+    [CmdletBinding()]
+    [OutputType([System.Security.SecureString])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [object]$InputObject
+    )
+
+    switch ($InputObject) {
+        { $_ -is [System.Security.SecureString] } {
+            return $_.Copy()
+        }
+        { $_ -is [string] } {
+            if ([string]::IsNullOrWhiteSpace([string]$_)) {
+                throw [System.ArgumentException]::new('Password cannot be null or empty.')
+            }
+
+            $chars = ([string]$_).ToCharArray()
+            try {
+                $secure = New-Object System.Security.SecureString
+                foreach ($char in $chars) {
+                    $secure.AppendChar($char)
+                }
+                $secure.MakeReadOnly()
+                return $secure
+            }
+            finally {
+                [Array]::Clear($chars, 0, $chars.Length)
+            }
+        }
+        default {
+            throw [System.ArgumentException]::new('Password must be provided as a SecureString or plain text string.')
+        }
+    }
+}
+
+function Get-SecureStorePlaintextData {
+    [CmdletBinding()]
+    [OutputType([byte[]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [System.Security.SecureString]$SecureString
+    )
+
+    $bstr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureString)
+    if ($bstr -eq [IntPtr]::Zero) {
+        throw 'Unable to marshal secure string.'
+    }
+
+    try {
+        $length = [System.Runtime.InteropServices.Marshal]::ReadInt32($bstr, -4)
+        $unicodeBytes = New-Object byte[] $length
+        [System.Runtime.InteropServices.Marshal]::Copy($bstr, $unicodeBytes, 0, $length)
+
+        try {
+            $chars = New-Object char[] ($length / 2)
+            [System.Buffer]::BlockCopy($unicodeBytes, 0, $chars, 0, $length)
+            try {
+                $utf8Bytes = [System.Text.Encoding]::UTF8.GetBytes($chars)
+                [Array]::Clear($chars, 0, $chars.Length)
+                return $utf8Bytes
+            }
+            finally {
+                [Array]::Clear($chars, 0, $chars.Length)
+            }
+        }
+        finally {
+            [Array]::Clear($unicodeBytes, 0, $unicodeBytes.Length)
+        }
+    }
+    finally {
+        [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+    }
+}
+
+function Write-SecureStoreFile {
+    [CmdletBinding()]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [byte[]]$Bytes
+    )
+
+    $directory = Split-Path -Path $Path -Parent
+    if (-not [string]::IsNullOrEmpty($directory) -and -not (Test-Path -LiteralPath $directory)) {
+        New-Item -ItemType Directory -Path $directory -Force | Out-Null
+    }
+
+    $tempFile = Join-Path -Path $directory -ChildPath ((New-Guid).Guid + '.tmp')
+
+    $fileStream = [System.IO.FileStream]::new(
+        $tempFile,
+        [System.IO.FileMode]::Create,
+        [System.IO.FileAccess]::Write,
+        [System.IO.FileShare]::None,
+        4096,
+        [System.IO.FileOptions]::WriteThrough
+    )
+
+    try {
+        $fileStream.Write($Bytes, 0, $Bytes.Length)
+        $fileStream.Flush($true)
+    }
+    finally {
+        $fileStream.Dispose()
+    }
+
+    Move-Item -LiteralPath $tempFile -Destination $Path -Force
+}
+
+function Read-SecureStoreByteArray {
+    [CmdletBinding()]
+    [OutputType([byte[]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Path
+    )
+
+    return [System.IO.File]::ReadAllBytes($Path)
+}
+
+function Read-SecureStoreText {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Path,
+
+        [Parameter()]
+        [System.Text.Encoding]$Encoding = [System.Text.Encoding]::UTF8
+    )
+
+    return [System.IO.File]::ReadAllText($Path, $Encoding)
+}
+
+function Protect-SecureStoreSecret {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [byte[]]$Plaintext,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [byte[]]$MasterKey
+    )
+
+    $salt = New-Object byte[] 16
+    $rng = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+    try {
+        $rng.GetBytes($salt)
+    }
+    finally {
+        $rng.Dispose()
+    }
+
+    $payload = $null
+    if ($script:SupportsAesGcm) {
+        $nonce = New-Object byte[] 12
+        $tag = New-Object byte[] 16
+
+        $rngForGcm = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+        try {
+            $rngForGcm.GetBytes($nonce)
+        }
+        finally {
+            $rngForGcm.Dispose()
+        }
+
+        $kdf = New-Object System.Security.Cryptography.Rfc2898DeriveBytes($MasterKey, $salt, 200000, [System.Security.Cryptography.HashAlgorithmName]::SHA256)
+        try {
+            $derivedKey = $kdf.GetBytes(32)
+        }
+        finally {
+            $kdf.Dispose()
+        }
+
+        $ciphertext = New-Object byte[] $Plaintext.Length
+        $aes = New-Object -TypeName $script:AesGcmType.FullName -ArgumentList (, $derivedKey)
+        try {
+            $aes.Encrypt($nonce, $Plaintext, $ciphertext, $tag)
+        }
+        finally {
+            if ($aes -is [System.IDisposable]) {
+                $aes.Dispose()
+            }
+            [Array]::Clear($derivedKey, 0, $derivedKey.Length)
+        }
+
+        $payload = [ordered]@{
+            Version = 2
+            KeyDerivation = [ordered]@{
+                Algorithm = 'PBKDF2'
+                Iterations = 200000
+                Hash = 'SHA256'
+                Salt = [Convert]::ToBase64String($salt)
+            }
+            Cipher = [ordered]@{
+                Algorithm = 'AES-GCM'
+                KeySize = 256
+                Nonce = [Convert]::ToBase64String($nonce)
+                Tag = [Convert]::ToBase64String($tag)
+                CipherText = [Convert]::ToBase64String($ciphertext)
+            }
+        }
+
+        [Array]::Clear($nonce, 0, $nonce.Length)
+        [Array]::Clear($tag, 0, $tag.Length)
+        [Array]::Clear($ciphertext, 0, $ciphertext.Length)
+    }
+    else {
+        $iv = New-Object byte[] 16
+        $nonceRng = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+        try {
+            $nonceRng.GetBytes($iv)
+        }
+        finally {
+            $nonceRng.Dispose()
+        }
+
+        $kdf = New-Object System.Security.Cryptography.Rfc2898DeriveBytes($MasterKey, $salt, 200000, [System.Security.Cryptography.HashAlgorithmName]::SHA256)
+        try {
+            $derivedKey = $kdf.GetBytes(64)
+        }
+        finally {
+            $kdf.Dispose()
+        }
+
+        $encryptionKey = New-Object byte[] 32
+        $hmacKey = New-Object byte[] 32
+        [System.Buffer]::BlockCopy($derivedKey, 0, $encryptionKey, 0, 32)
+        [System.Buffer]::BlockCopy($derivedKey, 32, $hmacKey, 0, 32)
+        [Array]::Clear($derivedKey, 0, $derivedKey.Length)
+
+        $aesProvider = [System.Security.Cryptography.Aes]::Create()
+        try {
+            $aesProvider.KeySize = 256
+            $aesProvider.Mode = [System.Security.Cryptography.CipherMode]::CBC
+            $aesProvider.Padding = [System.Security.Cryptography.PaddingMode]::PKCS7
+            $aesProvider.Key = $encryptionKey
+            $aesProvider.IV = $iv
+
+            $encryptor = $aesProvider.CreateEncryptor()
+            try {
+                $ciphertext = $encryptor.TransformFinalBlock($Plaintext, 0, $Plaintext.Length)
+            }
+            finally {
+                if ($encryptor -is [System.IDisposable]) {
+                    $encryptor.Dispose()
+                }
+            }
+        }
+        finally {
+            if ($aesProvider -is [System.IDisposable]) {
+                $aesProvider.Dispose()
+            }
+            [Array]::Clear($encryptionKey, 0, $encryptionKey.Length)
+        }
+
+        $hmacProvider = [System.Security.Cryptography.HMACSHA256]::new($hmacKey)
+        try {
+            $macInput = New-Object byte[] ($iv.Length + $ciphertext.Length)
+            try {
+                [System.Buffer]::BlockCopy($iv, 0, $macInput, 0, $iv.Length)
+                [System.Buffer]::BlockCopy($ciphertext, 0, $macInput, $iv.Length, $ciphertext.Length)
+                $tag = $hmacProvider.ComputeHash($macInput)
+            }
+            finally {
+                [Array]::Clear($macInput, 0, $macInput.Length)
+            }
+        }
+        finally {
+            $hmacProvider.Dispose()
+            [Array]::Clear($hmacKey, 0, $hmacKey.Length)
+        }
+
+        $payload = [ordered]@{
+            Version = 2
+            KeyDerivation = [ordered]@{
+                Algorithm = 'PBKDF2'
+                Iterations = 200000
+                Hash = 'SHA256'
+                Salt = [Convert]::ToBase64String($salt)
+            }
+            Cipher = [ordered]@{
+                Algorithm = 'AES-CBC-HMACSHA256'
+                KeySize = 256
+                IV = [Convert]::ToBase64String($iv)
+                Hmac = [Convert]::ToBase64String($tag)
+                CipherText = [Convert]::ToBase64String($ciphertext)
+            }
+        }
+
+        [Array]::Clear($iv, 0, $iv.Length)
+        [Array]::Clear($ciphertext, 0, $ciphertext.Length)
+        [Array]::Clear($tag, 0, $tag.Length)
+    }
+
+    [Array]::Clear($salt, 0, $salt.Length)
+
+    $json = $payload | ConvertTo-Json -Depth 4
+
+    [Array]::Clear($Plaintext, 0, $Plaintext.Length)
+
+    return $json
+}
+
+function Unprotect-SecureStoreSecret {
+    [CmdletBinding()]
+    [OutputType([byte[]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Payload,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [byte[]]$MasterKey
+    )
+
+    $data = $Payload | ConvertFrom-Json -ErrorAction Stop
+
+    if ($null -eq $data.Cipher -or $null -eq $data.KeyDerivation) {
+        throw 'Secret payload is missing metadata.'
+    }
+
+    $salt = [Convert]::FromBase64String([string]$data.KeyDerivation.Salt)
+
+    $iterations = if ($data.KeyDerivation.Iterations) { [int]$data.KeyDerivation.Iterations } else { 200000 }
+
+    $cipherAlgorithm = [string]$data.Cipher.Algorithm
+
+    $plaintext = $null
+
+    if ($cipherAlgorithm -eq 'AES-GCM') {
+        if (-not $script:SupportsAesGcm) {
+            throw 'Encrypted secret uses AES-GCM but the runtime does not support it.'
+        }
+
+        $nonce = [Convert]::FromBase64String([string]$data.Cipher.Nonce)
+        $tag = [Convert]::FromBase64String([string]$data.Cipher.Tag)
+        $ciphertext = [Convert]::FromBase64String([string]$data.Cipher.CipherText)
+
+        $kdf = New-Object System.Security.Cryptography.Rfc2898DeriveBytes($MasterKey, $salt, $iterations, [System.Security.Cryptography.HashAlgorithmName]::SHA256)
+        try {
+            $derivedKey = $kdf.GetBytes(32)
+        }
+        finally {
+            $kdf.Dispose()
+        }
+
+        $plaintext = New-Object byte[] $ciphertext.Length
+        $aes = New-Object -TypeName $script:AesGcmType.FullName -ArgumentList (, $derivedKey)
+        try {
+            $aes.Decrypt($nonce, $ciphertext, $tag, $plaintext)
+        }
+        catch {
+            throw 'Secret integrity check failed.'
+        }
+        finally {
+            if ($aes -is [System.IDisposable]) {
+                $aes.Dispose()
+            }
+            [Array]::Clear($derivedKey, 0, $derivedKey.Length)
+        }
+
+        [Array]::Clear($nonce, 0, $nonce.Length)
+        [Array]::Clear($tag, 0, $tag.Length)
+        [Array]::Clear($ciphertext, 0, $ciphertext.Length)
+    }
+    elseif ($cipherAlgorithm -eq 'AES-CBC-HMACSHA256') {
+        $iv = [Convert]::FromBase64String([string]$data.Cipher.IV)
+        $hmac = [Convert]::FromBase64String([string]$data.Cipher.Hmac)
+        $ciphertext = [Convert]::FromBase64String([string]$data.Cipher.CipherText)
+
+        $kdf = New-Object System.Security.Cryptography.Rfc2898DeriveBytes($MasterKey, $salt, $iterations, [System.Security.Cryptography.HashAlgorithmName]::SHA256)
+        try {
+            $derivedKey = $kdf.GetBytes(64)
+        }
+        finally {
+            $kdf.Dispose()
+        }
+
+        $encryptionKey = New-Object byte[] 32
+        $hmacKey = New-Object byte[] 32
+        [System.Buffer]::BlockCopy($derivedKey, 0, $encryptionKey, 0, 32)
+        [System.Buffer]::BlockCopy($derivedKey, 32, $hmacKey, 0, 32)
+        [Array]::Clear($derivedKey, 0, $derivedKey.Length)
+
+        $hmacProvider = [System.Security.Cryptography.HMACSHA256]::new($hmacKey)
+        try {
+            $macInput = New-Object byte[] ($iv.Length + $ciphertext.Length)
+            try {
+                [System.Buffer]::BlockCopy($iv, 0, $macInput, 0, $iv.Length)
+                [System.Buffer]::BlockCopy($ciphertext, 0, $macInput, $iv.Length, $ciphertext.Length)
+                $computedHmac = $hmacProvider.ComputeHash($macInput)
+            }
+            finally {
+                [Array]::Clear($macInput, 0, $macInput.Length)
+            }
+        }
+        finally {
+            $hmacProvider.Dispose()
+            [Array]::Clear($hmacKey, 0, $hmacKey.Length)
+        }
+
+        if (-not (Test-SecureStoreFixedTimeEqual -Left $computedHmac -Right $hmac)) {
+            [Array]::Clear($iv, 0, $iv.Length)
+            [Array]::Clear($ciphertext, 0, $ciphertext.Length)
+            [Array]::Clear($hmac, 0, $hmac.Length)
+            [Array]::Clear($computedHmac, 0, $computedHmac.Length)
+            throw 'Secret integrity check failed.'
+        }
+
+        [Array]::Clear($computedHmac, 0, $computedHmac.Length)
+
+        $aesProvider = [System.Security.Cryptography.Aes]::Create()
+        try {
+            $aesProvider.KeySize = 256
+            $aesProvider.Mode = [System.Security.Cryptography.CipherMode]::CBC
+            $aesProvider.Padding = [System.Security.Cryptography.PaddingMode]::PKCS7
+            $aesProvider.Key = $encryptionKey
+            $aesProvider.IV = $iv
+
+            $decryptor = $aesProvider.CreateDecryptor()
+            try {
+                $plaintext = $decryptor.TransformFinalBlock($ciphertext, 0, $ciphertext.Length)
+            }
+            finally {
+                if ($decryptor -is [System.IDisposable]) {
+                    $decryptor.Dispose()
+                }
+            }
+        }
+        catch {
+            throw 'Secret integrity check failed.'
+        }
+        finally {
+            if ($aesProvider -is [System.IDisposable]) {
+                $aesProvider.Dispose()
+            }
+            [Array]::Clear($encryptionKey, 0, $encryptionKey.Length)
+        }
+
+        [Array]::Clear($iv, 0, $iv.Length)
+        [Array]::Clear($ciphertext, 0, $ciphertext.Length)
+        [Array]::Clear($hmac, 0, $hmac.Length)
+    }
+    else {
+        throw "Unsupported cipher algorithm '$cipherAlgorithm'."
+    }
+
+    [Array]::Clear($salt, 0, $salt.Length)
+
+    return $plaintext
+}
 
 # Import private helper functions
-. "$PSScriptRoot\Sync-SecureStoreWorkingDirectory.ps1"
+. "$PSScriptRoot/Sync-SecureStoreWorkingDirectory.ps1"
 
 # Import public functions
 . "$PSScriptRoot\New-SecureStoreSecret.ps1"
@@ -21,20 +615,10 @@ $script:DefaultSecureStorePath = "C:\SecureStore"
 Export-ModuleMember -Function @(
     'New-SecureStoreSecret',
     'Get-SecureStoreSecret',
-    'Get-SecureStoreList', 
+    'Get-SecureStoreList',
     'Test-SecureStoreEnvironment',
     'New-SecureStoreCertificate'
 )
 
 # Module initialization
 Write-Verbose "SecureStore v2.0 loaded - Default path: $script:DefaultSecureStorePath"
-
-# Create default SecureStore structure on module load if it doesn't exist
-if (-not (Test-Path $script:DefaultSecureStorePath)) {
-    try {
-        Sync-SecureStoreWorkingDirectory -BasePath $script:DefaultSecureStorePath | Out-Null
-        Write-Verbose "Created default SecureStore structure at $script:DefaultSecureStorePath"
-    } catch {
-        Write-Warning "Could not create default SecureStore structure: $($_.Exception.Message)"
-    }
-}

--- a/Sync-SecureStoreWorkingDirectory.ps1
+++ b/Sync-SecureStoreWorkingDirectory.ps1
@@ -1,34 +1,74 @@
-﻿function Sync-SecureStoreWorkingDirectory {
+function Sync-SecureStoreWorkingDirectory {
     [CmdletBinding()]
+    [OutputType([hashtable])]
     param(
-        [Parameter(Mandatory = $false)]
-        [string]$BasePath = "C:\SecureStore"
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]$BasePath
     )
-    
+
     # Sync PowerShell and .NET directories
     $psLocation = (Get-Location).Path
     $netLocation = [System.IO.Directory]::GetCurrentDirectory()
-    
+
     if ($psLocation -ne $netLocation) {
         Write-Verbose "Syncing .NET directory from '$netLocation' to '$psLocation'"
         [System.IO.Directory]::SetCurrentDirectory($psLocation)
     }
-    
-    # Ensure base path is absolute
-    $resolvedBasePath = [System.IO.Path]::GetFullPath($BasePath)
-    
+
+    if (-not $PSBoundParameters.ContainsKey('BasePath') -or [string]::IsNullOrWhiteSpace($BasePath)) {
+        $BasePath = Get-SecureStoreDefaultPath
+    }
+
+    $resolvedInputPath = [System.IO.Path]::GetFullPath($BasePath)
+
+    $leafName = Split-Path -Path $resolvedInputPath -Leaf
+    $resolvedBasePath = $resolvedInputPath
+    $secretOverridePath = $null
+
+    if ($leafName -and ($leafName.Equals('secrets', [System.StringComparison]::InvariantCultureIgnoreCase) -or $leafName.Equals('secret', [System.StringComparison]::InvariantCultureIgnoreCase))) {
+        $secretOverridePath = $resolvedInputPath
+        $parentPath = Split-Path -Path $resolvedInputPath -Parent
+        if (-not [string]::IsNullOrWhiteSpace($parentPath)) {
+            $resolvedBasePath = $parentPath
+        }
+    }
+
     # Create SecureStore folder structure
-    $binDir = [System.IO.Path]::Combine($resolvedBasePath, "bin")
-    $secretDir = [System.IO.Path]::Combine($resolvedBasePath, "secrets")
-    $certsDir = [System.IO.Path]::Combine($resolvedBasePath, "certs")
-    
-    foreach ($dir in @($resolvedBasePath, $binDir, $secretDir, $certsDir)) {
-        if (-not (Test-Path $dir)) {
+    $binDir = Join-Path -Path $resolvedBasePath -ChildPath 'bin'
+    $preferredSecretDir = if ($secretOverridePath -and $leafName.Equals('secrets', [System.StringComparison]::InvariantCultureIgnoreCase)) {
+        $secretOverridePath
+    }
+    else {
+        Join-Path -Path $resolvedBasePath -ChildPath 'secrets'
+    }
+
+    $legacySecretDir = if ($secretOverridePath -and $leafName.Equals('secret', [System.StringComparison]::InvariantCultureIgnoreCase)) {
+        $secretOverridePath
+    }
+    else {
+        Join-Path -Path $resolvedBasePath -ChildPath 'secret'
+    }
+
+    $certsDir = Join-Path -Path $resolvedBasePath -ChildPath 'certs'
+
+    $secretDir = $preferredSecretDir
+
+    if ((Test-Path -LiteralPath $legacySecretDir) -and -not (Test-Path -LiteralPath $preferredSecretDir)) {
+        $secretDir = $legacySecretDir
+        if (-not $script:LegacySecretWarningIssued) {
+            Write-Warning "The 'secret' folder name is deprecated and will be removed in a future major version. Please migrate to 'secrets'."
+            $script:LegacySecretWarningIssued = $true
+        }
+    }
+
+    foreach ($dir in @($resolvedBasePath, $binDir, $preferredSecretDir, $certsDir)) {
+        if (-not [string]::IsNullOrWhiteSpace($dir) -and -not (Test-Path -LiteralPath $dir)) {
             Write-Verbose "Creating directory: $dir"
             New-Item -Path $dir -ItemType Directory -Force | Out-Null
         }
     }
-    
+
     return @{
         BasePath = $resolvedBasePath
         BinPath = $binDir

--- a/tests/SecureStore.Tests.ps1
+++ b/tests/SecureStore.Tests.ps1
@@ -1,0 +1,569 @@
+Import-Module "$PSScriptRoot/../SecureStore.psd1" -Force
+
+Describe 'SecureStore defaults' {
+    It 'uses ProgramData on Windows platforms' {
+        InModuleScope SecureStore {
+            $originalFlag = $script:IsWindowsPlatform
+            $originalProgramData = $env:ProgramData
+            try {
+                $script:IsWindowsPlatform = $true
+                $env:ProgramData = 'C:\\ProgramData'
+                $expected = [System.IO.Path]::Combine('C:\\ProgramData', 'SecureStore')
+                Get-SecureStoreDefaultPath | Should -Be $expected
+            }
+            finally {
+                $script:IsWindowsPlatform = $originalFlag
+                $env:ProgramData = $originalProgramData
+            }
+        }
+    }
+
+    It 'uses the home directory on non-Windows platforms' {
+        InModuleScope SecureStore {
+            $originalFlag = $script:IsWindowsPlatform
+            $originalHome = $env:HOME
+            try {
+                $script:IsWindowsPlatform = $false
+                $env:HOME = '/home/tester'
+                [System.Environment]::SetEnvironmentVariable('HOME', '/home/tester')
+                Get-SecureStoreDefaultPath | Should -Be (Join-Path -Path $env:HOME -ChildPath '.securestore')
+            }
+            finally {
+                $script:IsWindowsPlatform = $originalFlag
+                $env:HOME = $originalHome
+                [System.Environment]::SetEnvironmentVariable('HOME', $originalHome)
+            }
+        }
+    }
+}
+
+Describe 'SecureStore secure string helpers' {
+    It 'transforms plain text values using the argument transformation attribute' {
+        InModuleScope SecureStore {
+            $attribute = [SecureStoreSecureStringTransformationAttribute]::new()
+            $secure = $attribute.Transform($ExecutionContext, 'topsecret')
+            $secure | Should -BeOfType ([System.Security.SecureString])
+
+            $bytes = Get-SecureStorePlaintextData -SecureString $secure
+            [System.Text.Encoding]::UTF8.GetString($bytes) | Should -Be 'topsecret'
+        }
+    }
+
+    It 'converts arrays of plain text to secure strings' {
+        InModuleScope SecureStore {
+            $attribute = [SecureStoreSecureStringTransformationAttribute]::new()
+            $result = $attribute.Transform($ExecutionContext, @('first', 'second'))
+
+            $result | Should -HaveCount 2
+            foreach ($entry in $result) {
+                $entry | Should -BeOfType ([System.Security.SecureString])
+            }
+        }
+    }
+}
+
+Describe 'Sync-SecureStoreWorkingDirectory' {
+    It 'accepts legacy secret folder but warns about deprecation' {
+        InModuleScope SecureStore {
+            $script:LegacySecretWarningIssued = $false
+            Mock -CommandName Test-Path -ModuleName SecureStore -MockWith {
+                param(
+                    [string]$Path,
+                    [string]$LiteralPath
+                )
+
+                $target = if ($PSBoundParameters.ContainsKey('LiteralPath')) {
+                    $LiteralPath
+                }
+                elseif ($PSBoundParameters.ContainsKey('Path')) {
+                    $Path
+                }
+                else {
+                    $null
+                }
+
+                switch -Wildcard ($target) {
+                    '*secrets' { return $false }
+                    '*secret' { return $true }
+                    default { return $true }
+                }
+            }
+            Mock -CommandName New-Item -ModuleName SecureStore
+            Mock -CommandName Write-Warning
+
+            $result = Sync-SecureStoreWorkingDirectory -BasePath '/var/lib/securestore'
+            $result.SecretPath | Should -Match 'secrets?$'
+            Assert-MockCalled -CommandName Write-Warning -Times 1
+        }
+    }
+
+    It 'creates the preferred secrets folder when none exists' {
+        InModuleScope SecureStore {
+            Mock -CommandName Test-Path -ModuleName SecureStore -MockWith {
+                param(
+                    [string]$Path,
+                    [string]$LiteralPath
+                )
+
+                $target = if ($PSBoundParameters.ContainsKey('LiteralPath')) {
+                    $LiteralPath
+                }
+                elseif ($PSBoundParameters.ContainsKey('Path')) {
+                    $Path
+                }
+                else {
+                    $null
+                }
+
+                [void]$target
+                return $false
+            }
+            Mock -CommandName New-Item -ModuleName SecureStore
+
+            $result = Sync-SecureStoreWorkingDirectory -BasePath '/opt/securestore'
+            $result.SecretPath | Should -Match 'secrets$'
+        }
+    }
+
+    It 'treats -FolderPath values pointing to the secrets directory as the store root' {
+        InModuleScope SecureStore {
+            Mock -CommandName Test-Path -ModuleName SecureStore -MockWith {
+                param(
+                    [string]$Path,
+                    [string]$LiteralPath
+                )
+
+                $target = if ($PSBoundParameters.ContainsKey('LiteralPath')) {
+                    $LiteralPath
+                }
+                elseif ($PSBoundParameters.ContainsKey('Path')) {
+                    $Path
+                }
+                else {
+                    $null
+                }
+
+                [void]$target
+                return $false
+            }
+            Mock -CommandName New-Item -ModuleName SecureStore
+
+            $inputPath = '/srv/app/secrets'
+            $expectedBase = Split-Path -Path ([System.IO.Path]::GetFullPath($inputPath)) -Parent
+
+            $result = Sync-SecureStoreWorkingDirectory -BasePath $inputPath
+            $result.SecretPath | Should -Be (Join-Path -Path $result.BasePath -ChildPath 'secrets')
+            $result.BasePath | Should -Be $expectedBase
+        }
+    }
+}
+
+Describe 'New-SecureStoreSecret' {
+    BeforeEach {
+        InModuleScope SecureStore {
+            Mock -CommandName Sync-SecureStoreWorkingDirectory -ModuleName SecureStore -MockWith {
+                return [PSCustomObject]@{
+                    BasePath  = '/securestore'
+                    BinPath   = '/securestore/bin'
+                    SecretPath = '/securestore/secrets'
+                    CertsPath = '/securestore/certs'
+                }
+            }
+        }
+    }
+
+    It 'respects -WhatIf and avoids file writes' {
+        InModuleScope SecureStore {
+            Mock -CommandName Test-Path -ModuleName SecureStore -MockWith {
+                param(
+                    [string]$Path,
+                    [string]$LiteralPath
+                )
+
+                $target = if ($PSBoundParameters.ContainsKey('LiteralPath')) {
+                    $LiteralPath
+                }
+                elseif ($PSBoundParameters.ContainsKey('Path')) {
+                    $Path
+                }
+                else {
+                    $null
+                }
+
+                [void]$target
+                return $false
+            }
+            Mock -CommandName Write-SecureStoreFile -ModuleName SecureStore
+
+            New-SecureStoreSecret -KeyName 'test' -SecretFileName 'secret.json' -Password 'value' -WhatIf
+
+            Assert-MockCalled -CommandName Write-SecureStoreFile -ModuleName SecureStore -Times 0
+        }
+    }
+
+    It 'stores encrypted secret data using authenticated encryption' {
+        InModuleScope SecureStore {
+            $writes = @{}
+            Mock -CommandName Test-Path -ModuleName SecureStore -MockWith {
+                param(
+                    [string]$Path,
+                    [string]$LiteralPath
+                )
+
+                $target = if ($PSBoundParameters.ContainsKey('LiteralPath')) {
+                    $LiteralPath
+                }
+                elseif ($PSBoundParameters.ContainsKey('Path')) {
+                    $Path
+                }
+                else {
+                    $null
+                }
+
+                [void]$target
+                return $false
+            }
+            Mock -CommandName Write-SecureStoreFile -ModuleName SecureStore -MockWith {
+                param($Path, $Bytes)
+                $writes[$Path] = [byte[]]$Bytes.Clone()
+            }
+
+            New-SecureStoreSecret -KeyName 'encKey' -SecretFileName 'secret.txt' -Password 'superSecret!' -Confirm:$false
+
+            $keyPath = '/securestore/bin/encKey.bin'
+            $secretPath = '/securestore/secrets/secret.txt'
+            $writes.ContainsKey($keyPath) | Should -BeTrue
+            $writes.ContainsKey($secretPath) | Should -BeTrue
+
+            $payload = [System.Text.Encoding]::UTF8.GetString($writes[$secretPath])
+            $payloadObject = $payload | ConvertFrom-Json
+            if ($script:SupportsAesGcm) {
+                $payloadObject.Cipher.Algorithm | Should -Be 'AES-GCM'
+            }
+            else {
+                $payloadObject.Cipher.Algorithm | Should -Be 'AES-CBC-HMACSHA256'
+            }
+
+            $plaintext = Unprotect-SecureStoreSecret -Payload $payload -MasterKey $writes[$keyPath]
+            [System.Text.Encoding]::UTF8.GetString($plaintext) | Should -Be 'superSecret!'
+        }
+    }
+
+    It 'falls back to AES-CBC with HMAC when AES-GCM is unavailable' {
+        InModuleScope SecureStore {
+            $writes = @{}
+            $originalSupport = $script:SupportsAesGcm
+            try {
+                $script:SupportsAesGcm = $false
+
+                Mock -CommandName Test-Path -ModuleName SecureStore -MockWith {
+                    param(
+                        [string]$Path,
+                        [string]$LiteralPath
+                    )
+
+                    $target = if ($PSBoundParameters.ContainsKey('LiteralPath')) {
+                        $LiteralPath
+                    }
+                    elseif ($PSBoundParameters.ContainsKey('Path')) {
+                        $Path
+                    }
+                    else {
+                        $null
+                    }
+
+                    [void]$target
+                    return $false
+                }
+
+                Mock -CommandName Write-SecureStoreFile -ModuleName SecureStore -MockWith {
+                    param($Path, $Bytes)
+                    $writes[$Path] = [byte[]]$Bytes.Clone()
+                }
+
+                New-SecureStoreSecret -KeyName 'legacyKey' -SecretFileName 'secret.txt' -Password 'compatSecret!' -Confirm:$false
+
+                $secretPath = '/securestore/secrets/secret.txt'
+                $payload = [System.Text.Encoding]::UTF8.GetString($writes[$secretPath])
+                ($payload | ConvertFrom-Json).Cipher.Algorithm | Should -Be 'AES-CBC-HMACSHA256'
+
+                $plaintext = Unprotect-SecureStoreSecret -Payload $payload -MasterKey $writes['/securestore/bin/legacyKey.bin']
+                [System.Text.Encoding]::UTF8.GetString($plaintext) | Should -Be 'compatSecret!'
+            }
+            finally {
+                $script:SupportsAesGcm = $originalSupport
+            }
+        }
+    }
+}
+
+Describe 'Get-SecureStoreSecret' {
+    BeforeEach {
+        InModuleScope SecureStore {
+            Mock -CommandName Sync-SecureStoreWorkingDirectory -ModuleName SecureStore -MockWith {
+                return [PSCustomObject]@{
+                    BasePath  = '/securestore'
+                    BinPath   = '/securestore/bin'
+                    SecretPath = '/securestore/secrets'
+                    CertsPath = '/securestore/certs'
+                }
+            }
+        }
+    }
+
+    It 'returns a PSCredential when requested' {
+        InModuleScope SecureStore {
+            $keyBytes = [byte[]](1..32)
+            $plaintext = [System.Text.Encoding]::UTF8.GetBytes('credSecret')
+            $payload = Protect-SecureStoreSecret -Plaintext $plaintext -MasterKey $keyBytes
+            Mock -CommandName Test-Path -ModuleName SecureStore -MockWith {
+                param(
+                    [string]$Path,
+                    [string]$LiteralPath
+                )
+
+                $target = if ($PSBoundParameters.ContainsKey('LiteralPath')) {
+                    $LiteralPath
+                }
+                elseif ($PSBoundParameters.ContainsKey('Path')) {
+                    $Path
+                }
+                else {
+                    $null
+                }
+
+                [void]$target
+                return $true
+            }
+            $originalReadBytes = Get-Command -Name Read-SecureStoreByteArray -CommandType Function
+            $originalReadText = Get-Command -Name Read-SecureStoreText -CommandType Function
+
+            $credential = $null
+
+            try {
+                Set-Item -Path function:Read-SecureStoreByteArray -Value ({
+                    param([string]$Path)
+                    [void]$Path
+                    return [byte[]]$keyBytes.Clone()
+                }).GetNewClosure()
+
+                Set-Item -Path function:Read-SecureStoreText -Value ({
+                    param([string]$Path, [System.Text.Encoding]$Encoding)
+                    [void]$Path
+                    [void]$Encoding
+                    return $payload
+                }).GetNewClosure()
+
+                $credential = Get-SecureStoreSecret -KeyName 'credKey' -SecretFileName 'secret.txt' -AsCredential -UserName 'alice'
+            }
+            finally {
+                if ($null -ne $originalReadBytes) {
+                    Set-Item -Path function:Read-SecureStoreByteArray -Value $originalReadBytes.ScriptBlock
+                }
+
+                if ($null -ne $originalReadText) {
+                    Set-Item -Path function:Read-SecureStoreText -Value $originalReadText.ScriptBlock
+                }
+            }
+
+            $credential.UserName | Should -Be 'alice'
+            $credential.GetNetworkCredential().Password | Should -Be 'credSecret'
+        }
+    }
+
+    It 'throws a sanitized error when the secret file is missing' {
+        InModuleScope SecureStore {
+            Mock -CommandName Test-Path -ModuleName SecureStore -MockWith {
+                param(
+                    [string]$Path,
+                    [string]$LiteralPath
+                )
+
+                $target = if ($PSBoundParameters.ContainsKey('LiteralPath')) {
+                    $LiteralPath
+                }
+                elseif ($PSBoundParameters.ContainsKey('Path')) {
+                    $Path
+                }
+                else {
+                    $null
+                }
+
+                if ($target -like '*bin/credKey.bin') { return $true }
+                return $false
+            }
+            Mock -CommandName Read-SecureStoreByteArray -ModuleName SecureStore -MockWith { param($Path) [void]$Path; return [byte[]]@(0) }
+
+            Should -Throw -ActualValue { Get-SecureStoreSecret -KeyName 'credKey' -SecretFileName 'missing.txt' } -ErrorId * -ExpectedMessage 'Failed to retrieve the requested secret.'
+        }
+    }
+}
+
+Describe 'New-SecureStoreCertificate' {
+    BeforeEach {
+        InModuleScope SecureStore {
+            Mock -CommandName Sync-SecureStoreWorkingDirectory -ModuleName SecureStore -MockWith {
+                return [PSCustomObject]@{
+                    BasePath  = '/securestore'
+                    BinPath   = '/securestore/bin'
+                    SecretPath = '/securestore/secrets'
+                    CertsPath = '/securestore/certs'
+                }
+            }
+            Mock -CommandName Test-Path -ModuleName SecureStore -MockWith {
+                param(
+                    [string]$Path,
+                    [string]$LiteralPath
+                )
+
+                $target = if ($PSBoundParameters.ContainsKey('LiteralPath')) {
+                    $LiteralPath
+                }
+                elseif ($PSBoundParameters.ContainsKey('Path')) {
+                    $Path
+                }
+                else {
+                    $null
+                }
+
+                [void]$target
+                return $false
+            }
+            Mock -CommandName Remove-Item -ModuleName SecureStore
+        }
+    }
+
+    It 'rejects invalid key length for ECDSA' {
+        InModuleScope SecureStore {
+            { New-SecureStoreCertificate -CertificateName 'invalid' -Password 'pass123!' -Algorithm ECDSA -KeyLength 4096 -Confirm:$false } | Should -Throw
+        }
+    }
+
+    It 'honors -WhatIf and avoids generating certificates' {
+        InModuleScope SecureStore {
+            function New-SelfSignedCertificate {
+                [CmdletBinding(SupportsShouldProcess = $true)]
+                param([Parameter(ValueFromRemainingArguments = $true)][object[]]$Arguments)
+                [void]$Arguments
+                if (-not $PSCmdlet.ShouldProcess('Test certificate stub', 'Generate')) {
+                    return
+                }
+            }
+            Mock -CommandName New-SelfSignedCertificate -ModuleName SecureStore -MockWith { throw 'Should not be called' }
+
+            New-SecureStoreCertificate -CertificateName 'whatif' -Password 'pass123!' -WhatIf
+        }
+    }
+
+    It 'exports certificate metadata and paths' {
+        InModuleScope SecureStore {
+            function New-SelfSignedCertificate {
+                [CmdletBinding(SupportsShouldProcess = $true)]
+                param([Parameter(ValueFromRemainingArguments = $true)][object[]]$Arguments)
+                [void]$Arguments
+                if (-not $PSCmdlet.ShouldProcess('Test certificate stub', 'Generate')) {
+                    return
+                }
+            }
+            function Export-PfxCertificate {
+                [CmdletBinding(SupportsShouldProcess = $true)]
+                param([Parameter(ValueFromRemainingArguments = $true)][object[]]$Arguments)
+                [void]$Arguments
+                if (-not $PSCmdlet.ShouldProcess('Test certificate stub', 'Export')) {
+                    return
+                }
+            }
+            $certObject = New-Object PSObject -Property @{ Thumbprint = 'ABC123'; NotAfter = (Get-Date).AddYears(1) }
+            $certObject | Add-Member -MemberType ScriptMethod -Name Export -Value { param($type) [void]$type; return [byte[]](1,2,3) }
+            $certObject | Add-Member -MemberType ScriptMethod -Name Dispose -Value { }
+            Mock -CommandName New-SelfSignedCertificate -ModuleName SecureStore -MockWith { return $certObject }
+            Mock -CommandName Export-PfxCertificate -ModuleName SecureStore
+            Mock -CommandName Move-Item -ModuleName SecureStore
+            Mock -CommandName Write-SecureStoreFile -ModuleName SecureStore
+
+            $result = New-SecureStoreCertificate -CertificateName 'app' -Password 'pass123!' -ExportPem -Confirm:$false
+            $result.CertificateName | Should -Be 'app'
+            $result.Paths.Pfx | Should -Match 'app.pfx$'
+            $result.Paths.Pem | Should -Match 'app.pem$'
+            $result.NotAfter | Should -BeGreaterThan (Get-Date)
+        }
+    }
+}
+
+Describe 'Get-SecureStoreList' {
+    BeforeEach {
+        InModuleScope SecureStore {
+            Mock -CommandName Sync-SecureStoreWorkingDirectory -ModuleName SecureStore -MockWith {
+                return [PSCustomObject]@{
+                    BasePath  = '/securestore'
+                    BinPath   = '/securestore/bin'
+                    SecretPath = '/securestore/secrets'
+                    CertsPath = '/securestore/certs'
+                }
+            }
+        }
+    }
+
+    It 'warns when certificates are nearing expiry' {
+        InModuleScope SecureStore {
+            Mock -CommandName Get-ChildItem -ModuleName SecureStore -MockWith {
+                param($LiteralPath, $Filter, $File)
+                [void]$Filter
+                [void]$File
+                switch ($LiteralPath) {
+                    '/securestore/bin' { return @([PSCustomObject]@{ Name = 'key.bin'; FullName = '/securestore/bin/key.bin' }) }
+                    '/securestore/secrets' { return @([PSCustomObject]@{ Name = 'secret.txt'; FullName = '/securestore/secrets/secret.txt' }) }
+                    '/securestore/certs' { return @([PSCustomObject]@{ Name = 'cert.cer'; FullName = '/securestore/certs/cert.cer'; Extension = '.cer' }) }
+                }
+            }
+
+            $fakeCert = New-Object PSObject -Property @{ Thumbprint = 'XYZ'; NotAfter = (Get-Date).AddDays(5) }
+            $fakeCert | Add-Member -MemberType ScriptMethod -Name Dispose -Value { }
+            Mock -CommandName New-Object -ModuleName SecureStore -ParameterFilter { $TypeName -eq 'System.Security.Cryptography.X509Certificates.X509Certificate2' } -MockWith { $fakeCert }
+            Mock -CommandName Write-Warning -ModuleName SecureStore
+
+            $result = Get-SecureStoreList
+            $result.Certificates | Should -HaveCount 1
+            $result.Certificates[0].ExpiresSoon | Should -BeTrue
+            Assert-MockCalled -CommandName Write-Warning -ModuleName SecureStore -Times 1
+        }
+    }
+}
+
+Describe 'Test-SecureStoreEnvironment' {
+    It 'reports readiness based on directory existence' {
+        InModuleScope SecureStore {
+            Mock -CommandName Sync-SecureStoreWorkingDirectory -ModuleName SecureStore -MockWith {
+                return [PSCustomObject]@{
+                    BasePath  = '/securestore'
+                    BinPath   = '/securestore/bin'
+                    SecretPath = '/securestore/secrets'
+                    CertsPath = '/securestore/certs'
+                }
+            }
+            Mock -CommandName Test-Path -ModuleName SecureStore -MockWith {
+                param(
+                    [string]$Path,
+                    [string]$LiteralPath
+                )
+
+                $target = if ($PSBoundParameters.ContainsKey('LiteralPath')) {
+                    $LiteralPath
+                }
+                elseif ($PSBoundParameters.ContainsKey('Path')) {
+                    $Path
+                }
+                else {
+                    $null
+                }
+
+                [void]$target
+                return $true
+            }
+
+            $status = Test-SecureStoreEnvironment
+            $status.Ready | Should -BeTrue
+            $status.Paths.SecretExists | Should -BeTrue
+        }
+    }
+}

--- a/tests/powershell-analyzer.sarif
+++ b/tests/powershell-analyzer.sarif
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "properties": {
+        "invocation": {
+          "arguments": [
+            "Invoke-ScriptAnalyzer -Path . -Recurse"
+          ]
+        }
+      },
+      "tool": {
+        "driver": {
+          "name": "PSScriptAnalyzer",
+          "informationUri": "https://github.com/PowerShell/PSScriptAnalyzer",
+          "version": "1.24.0",
+          "rules": []
+        }
+      },
+      "results": []
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add runtime detection for AES-GCM and an AES-CBC + HMAC-SHA256 fallback with constant-time integrity checks so secrets decrypt on down-level hosts
- extend the secret lifecycle tests to validate authenticated encryption metadata, CBC fallback behaviour, and refresh the SARIF artifact
- document the dual encryption support in the README for clarity

## Testing
- pwsh -NoLogo -Command "Invoke-Pester -Path tests"
- pwsh -NoLogo -Command "Invoke-Pester -Path tests -CodeCoverage SecureStore.psm1 -PassThru"
- pwsh -NoLogo -Command "Import-Module PSScriptAnalyzer -RequiredVersion 1.24.0 -Force; Invoke-ScriptAnalyzer -Path . -Recurse | Format-Table"

------
https://chatgpt.com/codex/tasks/task_e_68d4bee7b4348331af3533efd3dcafd8