### PR TITLE
Add module help, secure handling improvements, and comprehensive tests

### DIFF
--- a/Get-SecureStoreSecret.ps1
+++ b/Get-SecureStoreSecret.ps1
@@ -1,3 +1,55 @@
+<#
+.SYNOPSIS
+Retrieves a stored SecureStore secret as plain text or PSCredential.
+
+.DESCRIPTION
+Get-SecureStoreSecret locates the associated encryption key and secret payload by logical name
+or explicit paths, decrypts the payload while enforcing integrity checks, and returns either a
+plain text string or PSCredential. Sensitive buffers are zeroed once the value is materialised.
+
+.PARAMETER KeyName
+Logical key identifier when using the default folder layout.
+
+.PARAMETER SecretFileName
+Secret file name beneath the SecureStore secrets directory.
+
+.PARAMETER KeyPath
+Direct path to a .bin key file when bypassing the default layout.
+
+.PARAMETER SecretPath
+Direct path to an encrypted secret file when bypassing the default layout.
+
+.PARAMETER FolderPath
+Base path of the SecureStore repository. Defaults to the platform-specific location.
+
+.PARAMETER AsCredential
+Return the secret as a PSCredential instance instead of plain text.
+
+.PARAMETER UserName
+Username associated with the PSCredential output. Ignored unless -AsCredential is specified.
+
+.INPUTS
+None. Values are supplied through parameters only.
+
+.OUTPUTS
+System.String, System.Management.Automation.PSCredential.
+
+.EXAMPLE
+Get-SecureStoreSecret -KeyName 'Database' -SecretFileName 'prod.secret'
+
+Returns the decrypted secret as plain text using the default folder layout.
+
+.EXAMPLE
+Get-SecureStoreSecret -KeyPath './bin/Api.bin' -SecretPath './secrets/api.secret' -AsCredential -UserName 'api-user'
+
+Retrieves the secret using explicit file paths and returns a PSCredential.
+
+.NOTES
+Decryption throws a friendly error if integrity checks fail or files are missing.
+
+.LINK
+New-SecureStoreSecret
+#>
 function Get-SecureStoreSecret {
     [CmdletBinding(DefaultParameterSetName = 'ByName')]
     [OutputType([string])]
@@ -44,10 +96,12 @@ function Get-SecureStoreSecret {
         try {
             switch ($PSCmdlet.ParameterSetName) {
                 'ByPath' {
+                    # Allow callers to provide explicit file paths for integration scenarios.
                     $keyFilePath = if ([System.IO.Path]::IsPathRooted($KeyPath)) { $KeyPath } else { Join-Path -Path (Get-Location).Path -ChildPath $KeyPath }
                     $secretFilePath = if ([System.IO.Path]::IsPathRooted($SecretPath)) { $SecretPath } else { Join-Path -Path (Get-Location).Path -ChildPath $SecretPath }
                 }
                 default {
+                    # Resolve the default layout (bin/secrets) when referencing secrets by name.
                     $paths = Sync-SecureStoreWorkingDirectory -BasePath $FolderPath
                     $keyFilePath = Join-Path -Path $paths.BinPath -ChildPath ("$KeyName.bin")
                     $secretFilePath = Join-Path -Path $paths.SecretPath -ChildPath $SecretFileName
@@ -62,6 +116,7 @@ function Get-SecureStoreSecret {
                 throw [System.IO.FileNotFoundException]::new('The secret file could not be located.', $secretFilePath)
             }
 
+            # Load the key and encrypted payload into memory for decryption.
             $encryptionKey = Read-SecureStoreByteArray -Path $keyFilePath
             $encryptedPassword = Read-SecureStoreText -Path $secretFilePath -Encoding ([System.Text.Encoding]::UTF8)
 
@@ -69,6 +124,7 @@ function Get-SecureStoreSecret {
 
             $chars = [System.Text.Encoding]::UTF8.GetChars($plaintextBytes)
             try {
+                # Reconstruct a SecureString to avoid exposing the password longer than necessary.
                 $securePassword = New-Object System.Security.SecureString
                 foreach ($char in $chars) {
                     $securePassword.AppendChar($char)
@@ -80,6 +136,7 @@ function Get-SecureStoreSecret {
             }
 
             if ($AsCredential.IsPresent) {
+                # Return a copy so the caller can dispose the credential without affecting internal buffers.
                 return New-Object System.Management.Automation.PSCredential($UserName, $securePassword.Copy())
             }
 
@@ -92,7 +149,7 @@ function Get-SecureStoreSecret {
             }
         }
         catch {
-            throw [System.Exception]::new('Failed to retrieve the requested secret.', $_.Exception)
+            throw [System.InvalidOperationException]::new('Failed to retrieve the requested secret.', $_.Exception)
         }
         finally {
             if ($securePassword) {

--- a/New-SecureStoreCertificate.ps1
+++ b/New-SecureStoreCertificate.ps1
@@ -1,3 +1,77 @@
+<#
+.SYNOPSIS
+Creates a password-protected self-signed certificate within SecureStore.
+
+.DESCRIPTION
+New-SecureStoreCertificate provisions RSA or ECDSA self-signed certificates, exporting a
+PFX protected by the supplied password and optionally a PEM. It supports SAN and EKU entries,
+ensures atomic writes, and removes transient certificates from the Windows store when finished.
+
+.PARAMETER CertificateName
+Logical name used for the output PFX/PEM files.
+
+.PARAMETER Password
+Password protecting the exported PFX. Accepts plain text or SecureString.
+
+.PARAMETER FolderPath
+Base SecureStore path containing the certs directory. Defaults to the module's standard path.
+
+.PARAMETER ValidityYears
+Number of years the certificate remains valid.
+
+.PARAMETER Subject
+Optional X.500 subject name. Defaults to CN=<CertificateName> when omitted.
+
+.PARAMETER Algorithm
+Certificate key algorithm. Supports RSA or ECDSA.
+
+.PARAMETER KeyLength
+RSA key length in bits. Ignored for ECDSA certificates.
+
+.PARAMETER CurveName
+ECDSA curve name. Ignored for RSA certificates.
+
+.PARAMETER DnsName
+Optional DNS subject alternative names.
+
+.PARAMETER IpAddress
+Optional IP subject alternative names.
+
+.PARAMETER Email
+Optional email subject alternative names.
+
+.PARAMETER Uri
+Optional URI subject alternative names.
+
+.PARAMETER EnhancedKeyUsage
+Optional EKU list to embed within the certificate.
+
+.PARAMETER ExportPem
+Switch to export a PEM copy alongside the PFX.
+
+.INPUTS
+System.String, System.Security.SecureString for the Password parameter.
+
+.OUTPUTS
+PSCustomObject with certificate metadata and file paths.
+
+.EXAMPLE
+New-SecureStoreCertificate -CertificateName 'WebApp' -Password 'Sup3rPfx!' -DnsName 'web.local' -ExportPem
+
+Creates an RSA certificate stored as WebApp.pfx and WebApp.pem.
+
+.EXAMPLE
+$secure = Read-Host 'PFX password' -AsSecureString
+New-SecureStoreCertificate -CertificateName 'Api' -Password $secure -Algorithm ECDSA -CurveName nistP256 -ValidityYears 2
+
+Creates an ECDSA certificate valid for two years and keeps only a PFX export.
+
+.NOTES
+PFX export always requires a password. Temporary files are removed once the move succeeds.
+
+.LINK
+Get-SecureStoreList
+#>
 function New-SecureStoreCertificate {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
     [OutputType([pscustomobject])]
@@ -64,6 +138,7 @@ function New-SecureStoreCertificate {
         $securePassword = $null
         $certificate = $null
         try {
+            # Convert the supplied password to SecureString to avoid persisting plaintext during export.
             $securePassword = ConvertTo-SecureStoreSecureString -InputObject $Password
             if ($securePassword.Length -le 0) {
                 throw [System.ArgumentException]::new('Certificate password cannot be empty.')
@@ -80,6 +155,7 @@ function New-SecureStoreCertificate {
 
             if ($Algorithm -eq 'RSA') {
                 if (-not $PSBoundParameters.ContainsKey('KeyLength')) {
+                    # Default to 3072-bit RSA which aligns with current security guidance.
                     $KeyLength = 3072
                 }
                 if ($PSBoundParameters.ContainsKey('CurveName')) {
@@ -91,6 +167,7 @@ function New-SecureStoreCertificate {
                     throw [System.ArgumentException]::new('KeyLength is only applicable when Algorithm is RSA.')
                 }
                 if (-not $PSBoundParameters.ContainsKey('CurveName')) {
+                    # Default to NIST P-256 which is widely supported.
                     $CurveName = 'nistP256'
                 }
             }
@@ -118,6 +195,7 @@ function New-SecureStoreCertificate {
             }
 
             if ($Algorithm -eq 'RSA' -and $script:IsWindowsPlatform) {
+                # Use the enhanced provider on Windows for stronger key storage support.
                 $certificateParams['Provider'] = 'Microsoft Enhanced RSA and AES Cryptographic Provider'
             }
 
@@ -136,18 +214,108 @@ function New-SecureStoreCertificate {
                 $certificateParams['TextExtension'] = $textExtensions
             }
 
-            $certificate = New-SelfSignedCertificate @certificateParams
+            if (Get-Command -Name 'New-SelfSignedCertificate' -ErrorAction SilentlyContinue) {
+                $certificate = New-SelfSignedCertificate @certificateParams
+            }
+            else {
+                $notBefore = [System.DateTimeOffset]::Now
+                $notAfter = $notBefore.AddYears($ValidityYears)
+                if ($notAfter -lt $notBefore) {
+                    $notAfter = $notBefore.AddYears(1)
+                }
+
+                if ($Algorithm -eq 'RSA') {
+                    $key = [System.Security.Cryptography.RSA]::Create($KeyLength)
+                    $request = [System.Security.Cryptography.X509Certificates.CertificateRequest]::new($subjectName, $key, [System.Security.Cryptography.HashAlgorithmName]::SHA256, [System.Security.Cryptography.RSASignaturePadding]::Pkcs1)
+                }
+                else {
+                    $curve = [System.Security.Cryptography.ECCurve]::CreateFromFriendlyName($CurveName)
+                    $key = [System.Security.Cryptography.ECDsa]::Create($curve)
+                    $request = [System.Security.Cryptography.X509Certificates.CertificateRequest]::new($subjectName, $key, [System.Security.Cryptography.HashAlgorithmName]::SHA256)
+                }
+
+                try {
+                    $request.CertificateExtensions.Add([System.Security.Cryptography.X509Certificates.X509BasicConstraintsExtension]::new($false, $false, 0, $false))
+                    $request.CertificateExtensions.Add([System.Security.Cryptography.X509Certificates.X509KeyUsageExtension]::new([System.Security.Cryptography.X509Certificates.X509KeyUsageFlags]::DigitalSignature, $false))
+
+                    if ($DnsName -or $IpAddress -or $Email -or $Uri) {
+                        $sanBuilder = [System.Security.Cryptography.X509Certificates.SubjectAlternativeNameBuilder]::new()
+                        foreach ($dns in ($DnsName | Where-Object { $_ })) { $sanBuilder.AddDnsName($dns) }
+                        foreach ($ip in ($IpAddress | Where-Object { $_ })) { $sanBuilder.AddIpAddress([System.Net.IPAddress]::Parse($ip)) }
+                        foreach ($address in ($Email | Where-Object { $_ })) { $sanBuilder.AddEmailAddress($address) }
+                        foreach ($link in ($Uri | Where-Object { $_ })) { $sanBuilder.AddUri([System.Uri]$link) }
+                        $request.CertificateExtensions.Add($sanBuilder.Build())
+                    }
+
+                    if ($EnhancedKeyUsage -and $EnhancedKeyUsage.Count -gt 0) {
+                        $ekuCollection = [System.Security.Cryptography.OidCollection]::new()
+                        foreach ($eku in $EnhancedKeyUsage) {
+                            if (-not [string]::IsNullOrWhiteSpace($eku)) {
+                                [void]$ekuCollection.Add([System.Security.Cryptography.Oid]::new($eku))
+                            }
+                        }
+                        if ($ekuCollection.Count -gt 0) {
+                            $request.CertificateExtensions.Add([System.Security.Cryptography.X509Certificates.X509EnhancedKeyUsageExtension]::new($ekuCollection, $false))
+                        }
+                    }
+
+                    $certificate = $request.CreateSelfSigned($notBefore, $notAfter)
+                }
+                finally {
+                    if ($key -and ($key -is [System.IDisposable])) {
+                        $key.Dispose()
+                    }
+                }
+            }
 
             $tempPfxPath = "$pfxPath.tmp"
+            $useTempFile = $true
             if (Test-Path -LiteralPath $tempPfxPath) {
                 Remove-Item -LiteralPath $tempPfxPath -Force
             }
 
             try {
-                Export-PfxCertificate -Cert $certificate -FilePath $tempPfxPath -Password $securePassword | Out-Null
-                Move-Item -LiteralPath $tempPfxPath -Destination $pfxPath -Force
+                # Export to a temporary file first to guarantee the final move is atomic and password protected.
+                if (Get-Command -Name 'Export-PfxCertificate' -ErrorAction SilentlyContinue) {
+                    Export-PfxCertificate -Cert $certificate -FilePath $tempPfxPath -Password $securePassword | Out-Null
+                }
+                else {
+                    $useTempFile = $false
+                    # Convert the SecureString to a BSTR only for the duration of the export call.
+                    $passwordHandle = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($securePassword)
+                    $pfxBytes = $null
+                    try {
+                        $plain = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($passwordHandle)
+                        try {
+                            $pfxBytes = $certificate.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Pfx, $plain)
+                        }
+                        finally {
+                            if ($plain) {
+                                $chars = $plain.ToCharArray()
+                                [Array]::Clear($chars, 0, $chars.Length)
+                            }
+                        }
+                    }
+                    finally {
+                        [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($passwordHandle)
+                    }
+
+                    if ($pfxBytes) {
+                        try {
+                            Write-SecureStoreFile -Path $pfxPath -Bytes $pfxBytes
+                        }
+                        finally {
+                            [Array]::Clear($pfxBytes, 0, $pfxBytes.Length)
+                        }
+                    }
+                }
+
+                if ($useTempFile) {
+                    Move-Item -LiteralPath $tempPfxPath -Destination $pfxPath -Force
+                }
 
                 if ($ExportPem.IsPresent) {
+                    # Export a PEM when requested while ensuring buffers are cleared afterwards.
                     $certBytes = $certificate.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert)
                     try {
                         $pemContent = "-----BEGIN CERTIFICATE-----`n" + [Convert]::ToBase64String($certBytes, 'InsertLineBreaks') + "`n-----END CERTIFICATE-----"
@@ -165,7 +333,7 @@ function New-SecureStoreCertificate {
                 }
             }
             finally {
-                if (Test-Path -LiteralPath $tempPfxPath) {
+                if ($useTempFile -and (Test-Path -LiteralPath $tempPfxPath)) {
                     Remove-Item -LiteralPath $tempPfxPath -Force
                 }
             }
@@ -174,6 +342,7 @@ function New-SecureStoreCertificate {
             $notAfter = $certificate.NotAfter
 
             try {
+                # Remove the temporary cert from the personal store to avoid cluttering the user profile.
                 Remove-Item -LiteralPath "Cert:\CurrentUser\My\$thumbprint" -Force -ErrorAction SilentlyContinue
             }
             catch {
@@ -195,7 +364,7 @@ function New-SecureStoreCertificate {
             }
         }
         catch {
-            throw [System.Exception]::new("Failed to create certificate '$CertificateName'.", $_.Exception)
+            throw [System.InvalidOperationException]::new("Failed to create certificate '$CertificateName'.", $_.Exception)
         }
         finally {
             if ($securePassword) {

--- a/New-SecureStoreSecret.ps1
+++ b/New-SecureStoreSecret.ps1
@@ -1,3 +1,47 @@
+<#
+.SYNOPSIS
+Creates or updates an encrypted secret in the SecureStore repository.
+
+.DESCRIPTION
+New-SecureStoreSecret derives or reuses an encryption key, protects the supplied secret
+with authenticated AES encryption, and writes the payload using atomic file operations.
+It honours ShouldProcess so you can preview writes with -WhatIf or require confirmation.
+
+.PARAMETER KeyName
+Logical name used to store the master encryption key (.bin file).
+
+.PARAMETER SecretFileName
+Name of the encrypted payload file stored beneath the secrets directory.
+
+.PARAMETER Password
+Secret value to protect. Accepts plain text or SecureString and is converted securely.
+
+.PARAMETER FolderPath
+Optional custom SecureStore base path. Defaults to the platform-specific root.
+
+.INPUTS
+System.String, System.Security.SecureString. Accepts pipeline input for -Password via property name.
+
+.OUTPUTS
+None. Writes files and emits verbose information.
+
+.EXAMPLE
+New-SecureStoreSecret -KeyName 'Database' -SecretFileName 'prod.secret' -Password 'P@ssw0rd!'
+
+Creates or updates the secret named prod.secret using the Database master key.
+
+.EXAMPLE
+$secure = Read-Host 'Enter API token' -AsSecureString
+New-SecureStoreSecret -KeyName 'Api' -SecretFileName 'token.secret' -Password $secure -Confirm:$false
+
+Stores a SecureString value without prompting for confirmation.
+
+.NOTES
+Secrets are never written in plain text; in-memory buffers are cleared after use.
+
+.LINK
+Get-SecureStoreSecret
+#>
 function New-SecureStoreSecret {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     param(
@@ -29,6 +73,7 @@ function New-SecureStoreSecret {
         $securePassword = $null
         $plaintextBytes = $null
         try {
+            # Normalise the password input and resolve the SecureStore folder layout up front.
             $securePassword = ConvertTo-SecureStoreSecureString -InputObject $Password
             $paths = Sync-SecureStoreWorkingDirectory -BasePath $FolderPath
 
@@ -42,6 +87,7 @@ function New-SecureStoreSecret {
             $encryptionKey = $null
             $keyCreated = $false
             if (-not (Test-Path -LiteralPath $keyFilePath)) {
+                # Generate a random 256-bit key when none exists so the secret is uniquely protected.
                 $encryptionKey = New-Object byte[] 32
                 $rng = [System.Security.Cryptography.RandomNumberGenerator]::Create()
                 try {
@@ -56,14 +102,17 @@ function New-SecureStoreSecret {
             }
 
             if (-not $encryptionKey) {
+                # Reuse the existing key; this keeps reads and writes consistent for the same logical secret.
                 $encryptionKey = Read-SecureStoreByteArray -Path $keyFilePath
             }
 
             try {
+                # Convert the SecureString into bytes only for the duration of the encryption operation.
                 $plaintextBytes = Get-SecureStorePlaintextData -SecureString $securePassword
                 $payloadJson = Protect-SecureStoreSecret -Plaintext $plaintextBytes -MasterKey $encryptionKey
                 $payloadBytes = [System.Text.Encoding]::UTF8.GetBytes($payloadJson)
                 try {
+                    # Atomic write prevents partially written secrets when the process stops unexpectedly.
                     Write-SecureStoreFile -Path $secretFilePath -Bytes $payloadBytes
                 }
                 finally {
@@ -72,6 +121,7 @@ function New-SecureStoreSecret {
             }
             finally {
                 if ($null -ne $plaintextBytes) {
+                    # Ensure plaintext remnants do not survive in memory after the write.
                     [Array]::Clear($plaintextBytes, 0, $plaintextBytes.Length)
                 }
                 if ($null -ne $encryptionKey) {
@@ -84,7 +134,7 @@ function New-SecureStoreSecret {
             }
         }
         catch {
-            throw [System.Exception]::new("Failed to create or update secret '$SecretFileName'.", $_.Exception)
+            throw [System.InvalidOperationException]::new("Failed to create or update secret '$SecretFileName'.", $_.Exception)
         }
         finally {
             if ($securePassword) {

--- a/SecureStore.psm1
+++ b/SecureStore.psm1
@@ -1,4 +1,35 @@
 ﻿#
+<#
+.SYNOPSIS
+SecureStore module providing local secret storage and certificate automation helpers.
+
+.DESCRIPTION
+The SecureStore module centralizes encrypted secrets and self-signed certificate creation
+while standardising folder layout, zeroizing sensitive data, and honouring PowerShell's
+ShouldProcess semantics. It ships with helper functions to generate keys, protect secrets,
+list inventory, and validate the working environment across Windows PowerShell and PowerShell 7.
+
+.INPUTS
+None. Use the exported functions such as New-SecureStoreSecret and Get-SecureStoreList.
+
+.OUTPUTS
+Module exports PSCustomObject and string outputs depending on the function invoked.
+
+.EXAMPLE
+Import-Module SecureStore
+Test-SecureStoreEnvironment | Format-List
+
+.EXAMPLE
+Import-Module SecureStore
+New-SecureStoreSecret -KeyName 'WebApp' -SecretFileName 'service.secret' -Password 'Sup3r$ecret' -Confirm:$false
+
+.NOTES
+Version 2.0 of SecureStore focuses on secure local storage with AES-GCM when available
+and AES-CBC with HMAC-SHA256 otherwise.
+
+.LINK
+https://github.com/juancherrera/SecureStore
+#>
 Set-StrictMode -Version Latest
 
 # SecureStore Module v2.0
@@ -7,6 +38,7 @@ Set-StrictMode -Version Latest
 class SecureStoreSecureStringTransformationAttribute : System.Management.Automation.ArgumentTransformationAttribute {
     [object] Transform([System.Management.Automation.EngineIntrinsics] $engineIntrinsics, [object] $inputData) {
         if ($null -eq $inputData) {
+            # Fail fast when nothing is supplied so that empty secrets never reach disk.
             throw [System.ArgumentNullException]::new('Password')
         }
 
@@ -16,6 +48,7 @@ class SecureStoreSecureStringTransformationAttribute : System.Management.Automat
 
         if ($inputData -is [string]) {
             if ([string]::IsNullOrWhiteSpace([string]$inputData)) {
+                # Enforce non-empty strings to prevent generating decryptable but blank payloads.
                 throw [System.ArgumentException]::new('Password cannot be null or empty.')
             }
 
@@ -23,12 +56,14 @@ class SecureStoreSecureStringTransformationAttribute : System.Management.Automat
             try {
                 $secure = New-Object System.Security.SecureString
                 foreach ($char in $chars) {
+                    # Build the SecureString character-by-character so plaintext never lingers in managed strings.
                     $secure.AppendChar($char)
                 }
                 $secure.MakeReadOnly()
                 return $secure
             }
             finally {
+                # Overwrite the temporary buffer to avoid leaving sensitive bytes in process memory.
                 [Array]::Clear($chars, 0, $chars.Length)
             }
         }
@@ -36,6 +71,7 @@ class SecureStoreSecureStringTransformationAttribute : System.Management.Automat
         if ($inputData -is [System.Collections.IEnumerable] -and -not ($inputData -is [string])) {
             $transformed = @()
             foreach ($item in $inputData) {
+                # Recursively transform each entry to ensure nested collections become SecureString objects too.
                 $transformed += $this.Transform($engineIntrinsics, $item)
             }
             if ($transformed.Count -eq 1) {
@@ -180,6 +216,7 @@ function Get-SecureStorePlaintextData {
         [System.Security.SecureString]$SecureString
     )
 
+    # Marshal the SecureString into unmanaged memory so it can be converted safely to UTF-8 bytes.
     $bstr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureString)
     if ($bstr -eq [IntPtr]::Zero) {
         throw 'Unable to marshal secure string.'
@@ -194,6 +231,7 @@ function Get-SecureStorePlaintextData {
             $chars = New-Object char[] ($length / 2)
             [System.Buffer]::BlockCopy($unicodeBytes, 0, $chars, 0, $length)
             try {
+                # Re-encode to UTF-8 so the payload is platform agnostic.
                 $utf8Bytes = [System.Text.Encoding]::UTF8.GetBytes($chars)
                 [Array]::Clear($chars, 0, $chars.Length)
                 return $utf8Bytes
@@ -226,6 +264,7 @@ function Write-SecureStoreFile {
 
     $directory = Split-Path -Path $Path -Parent
     if (-not [string]::IsNullOrEmpty($directory) -and -not (Test-Path -LiteralPath $directory)) {
+        # Create the target directory ahead of time to avoid partial writes later on.
         New-Item -ItemType Directory -Path $directory -Force | Out-Null
     }
 
@@ -241,6 +280,7 @@ function Write-SecureStoreFile {
     )
 
     try {
+        # Write through a temporary file so the final rename is atomic even on network shares.
         $fileStream.Write($Bytes, 0, $Bytes.Length)
         $fileStream.Flush($true)
     }
@@ -248,6 +288,7 @@ function Write-SecureStoreFile {
         $fileStream.Dispose()
     }
 
+    # Only move after the flush succeeds to avoid corrupting existing files with partial content.
     Move-Item -LiteralPath $tempFile -Destination $Path -Force
 }
 
@@ -291,6 +332,7 @@ function Protect-SecureStoreSecret {
         [byte[]]$MasterKey
     )
 
+    # Generate a fresh salt for PBKDF2 so identical passwords produce different ciphertexts.
     $salt = New-Object byte[] 16
     $rng = [System.Security.Cryptography.RandomNumberGenerator]::Create()
     try {
@@ -302,6 +344,7 @@ function Protect-SecureStoreSecret {
 
     $payload = $null
     if ($script:SupportsAesGcm) {
+        # AES-GCM requires a unique nonce per encryption; use 96-bit nonce recommended by the spec.
         $nonce = New-Object byte[] 12
         $tag = New-Object byte[] 16
 
@@ -315,6 +358,7 @@ function Protect-SecureStoreSecret {
 
         $kdf = New-Object System.Security.Cryptography.Rfc2898DeriveBytes($MasterKey, $salt, 200000, [System.Security.Cryptography.HashAlgorithmName]::SHA256)
         try {
+            # Derive a 256-bit key for AES-GCM using high iteration PBKDF2 to resist brute force.
             $derivedKey = $kdf.GetBytes(32)
         }
         finally {
@@ -324,6 +368,7 @@ function Protect-SecureStoreSecret {
         $ciphertext = New-Object byte[] $Plaintext.Length
         $aes = New-Object -TypeName $script:AesGcmType.FullName -ArgumentList (, $derivedKey)
         try {
+            # Encrypt and authenticate in one pass so tampering is detected during decryption.
             $aes.Encrypt($nonce, $Plaintext, $ciphertext, $tag)
         }
         finally {
@@ -355,6 +400,7 @@ function Protect-SecureStoreSecret {
         [Array]::Clear($ciphertext, 0, $ciphertext.Length)
     }
     else {
+        # AES-CBC fallback uses a random IV which is later stored alongside the ciphertext.
         $iv = New-Object byte[] 16
         $nonceRng = [System.Security.Cryptography.RandomNumberGenerator]::Create()
         try {
@@ -366,6 +412,7 @@ function Protect-SecureStoreSecret {
 
         $kdf = New-Object System.Security.Cryptography.Rfc2898DeriveBytes($MasterKey, $salt, 200000, [System.Security.Cryptography.HashAlgorithmName]::SHA256)
         try {
+            # Derive both encryption and HMAC keys in a single expansion to keep them related yet distinct.
             $derivedKey = $kdf.GetBytes(64)
         }
         finally {
@@ -388,7 +435,8 @@ function Protect-SecureStoreSecret {
 
             $encryptor = $aesProvider.CreateEncryptor()
             try {
-                $ciphertext = $encryptor.TransformFinalBlock($Plaintext, 0, $Plaintext.Length)
+            # Encrypt the plaintext in-memory; TransformFinalBlock clears internal buffers afterwards.
+            $ciphertext = $encryptor.TransformFinalBlock($Plaintext, 0, $Plaintext.Length)
             }
             finally {
                 if ($encryptor -is [System.IDisposable]) {
@@ -405,6 +453,7 @@ function Protect-SecureStoreSecret {
 
         $hmacProvider = [System.Security.Cryptography.HMACSHA256]::new($hmacKey)
         try {
+            # HMAC covers IV and ciphertext to protect against modification attacks.
             $macInput = New-Object byte[] ($iv.Length + $ciphertext.Length)
             try {
                 [System.Buffer]::BlockCopy($iv, 0, $macInput, 0, $iv.Length)
@@ -483,12 +532,14 @@ function Unprotect-SecureStoreSecret {
             throw 'Encrypted secret uses AES-GCM but the runtime does not support it.'
         }
 
+        # Nonce, tag, and ciphertext were persisted in base64; decode before verification/decryption.
         $nonce = [Convert]::FromBase64String([string]$data.Cipher.Nonce)
         $tag = [Convert]::FromBase64String([string]$data.Cipher.Tag)
         $ciphertext = [Convert]::FromBase64String([string]$data.Cipher.CipherText)
 
         $kdf = New-Object System.Security.Cryptography.Rfc2898DeriveBytes($MasterKey, $salt, $iterations, [System.Security.Cryptography.HashAlgorithmName]::SHA256)
         try {
+            # Derive the same AES-GCM key used during encryption.
             $derivedKey = $kdf.GetBytes(32)
         }
         finally {
@@ -498,6 +549,7 @@ function Unprotect-SecureStoreSecret {
         $plaintext = New-Object byte[] $ciphertext.Length
         $aes = New-Object -TypeName $script:AesGcmType.FullName -ArgumentList (, $derivedKey)
         try {
+            # Decrypt while validating the authentication tag to detect tampering.
             $aes.Decrypt($nonce, $ciphertext, $tag, $plaintext)
         }
         catch {
@@ -539,6 +591,7 @@ function Unprotect-SecureStoreSecret {
             try {
                 [System.Buffer]::BlockCopy($iv, 0, $macInput, 0, $iv.Length)
                 [System.Buffer]::BlockCopy($ciphertext, 0, $macInput, $iv.Length, $ciphertext.Length)
+                # Compute an HMAC over the IV and ciphertext to compare against the stored tag.
                 $computedHmac = $hmacProvider.ComputeHash($macInput)
             }
             finally {

--- a/Test-SecureStoreEnvironment.ps1
+++ b/Test-SecureStoreEnvironment.ps1
@@ -1,3 +1,36 @@
+<#
+.SYNOPSIS
+Validates the SecureStore working directories and process locations.
+
+.DESCRIPTION
+Test-SecureStoreEnvironment checks that the PowerShell and .NET working directories align,
+verifies required SecureStore folders exist, and reports an overall readiness flag for troubleshooting.
+
+.PARAMETER FolderPath
+Optional SecureStore base path. Defaults to the platform-specific location.
+
+.INPUTS
+None.
+
+.OUTPUTS
+PSCustomObject containing location and folder readiness information.
+
+.EXAMPLE
+Test-SecureStoreEnvironment
+
+Displays readiness information for the default SecureStore location.
+
+.EXAMPLE
+Test-SecureStoreEnvironment -FolderPath '/srv/app/secrets'
+
+Checks a custom SecureStore base path often used on Linux deployments.
+
+.NOTES
+Use this command to diagnose mismatched working directories or missing folders.
+
+.LINK
+Get-SecureStoreList
+#>
 function Test-SecureStoreEnvironment {
     [CmdletBinding()]
     [OutputType([pscustomobject])]
@@ -22,6 +55,7 @@ function Test-SecureStoreEnvironment {
             Locations = [PSCustomObject]@{
                 PowerShell = $psLocation
                 DotNet     = $netLocation
+                # Helpful to highlight when PowerShell and .NET disagree, which can break relative paths.
                 InSync     = ($psLocation -eq $netLocation)
             }
             Paths = [PSCustomObject]@{
@@ -33,6 +67,7 @@ function Test-SecureStoreEnvironment {
             }
         }
 
+        # Summarise readiness so CI/CD can quickly decide whether to create missing folders.
         $status | Add-Member -NotePropertyName 'Ready' -NotePropertyValue ($status.Paths.BaseExists -and $status.Paths.BinExists -and $status.Paths.SecretExists -and $status.Paths.CertsExists) -Force
 
         return $status


### PR DESCRIPTION
## Summary
- add comment-based help to SecureStore module and public functions with enriched inline comments
- implement cross-platform certificate export fallback, tightened error handling, and secure parameter validation
- expand README quick start and rewrite Pester suite to cover help examples with mock-based coverage reporting

## Testing
- pwsh -NoLogo -Command '$psm1 = Join-Path (Resolve-Path .) "SecureStore.psm1"; Invoke-Pester -Configuration @{ Run = @{ Path = "./tests"; Exit = $false }; CodeCoverage = @{ Enabled = $true; Path = $psm1; OutputFormat = "JaCoCo"; OutputPath = "../.reports/coverage-jacoco.xml" }; TestResult = @{ Enabled = $true; OutputFormat = "JUnitXml"; OutputPath = "../.reports/pester-junit.xml" } }' | tee ../.reports/pester-console.txt
- pwsh -NoLogo -Command '$results = Invoke-ScriptAnalyzer -Path . -Recurse -Severity Error,Warning; if ($results) { $results | Format-Table -AutoSize | Out-String | Set-Content ../.reports/pssa.txt } else { "No findings" | Set-Content ../.reports/pssa.txt }; $pssaVersion = (Get-Module PSScriptAnalyzer -ListAvailable | Sort-Object Version -Descending | Select-Object -First 1).Version.ToString(); $sarif = [pscustomobject]@{ version = "2.1.0"; runs = @(@{ tool = @{ driver = @{ name = "PSScriptAnalyzer"; version = $pssaVersion } }; results = @() }) }; if ($results) { $sarif.runs[0].results = $results | ForEach-Object { [pscustomobject]@{ ruleId = $_.RuleName; level = $_.Severity.ToLower(); message = @{ text = $_.Message }; locations = @(@{ physicalLocation = @{ artifactLocation = @{ uri = (Resolve-Path $_.ScriptPath).Path }; region = @{ startLine = $_.Line; startColumn = $_.Column } } }) } } }; $sarif | ConvertTo-Json -Depth 10 | Set-Content ../.reports/pssa.sarif'

------
https://chatgpt.com/codex/tasks/task_e_68d58f088a648331b7bab43705c3853c