### PR TITLE
Fix custom attribute lookup for SecureStore cmdlets

### DIFF
--- a/New-SecureStoreCertificate.ps1
+++ b/New-SecureStoreCertificate.ps1
@@ -82,7 +82,7 @@ function New-SecureStoreCertificate {
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNull()]
-        [SecureStoreSecureStringTransformation()]
+        [SecureStoreSecureStringTransformationAttribute()]
         [System.Security.SecureString]$Password,
 
         [Parameter()]

--- a/New-SecureStoreSecret.ps1
+++ b/New-SecureStoreSecret.ps1
@@ -55,7 +55,7 @@ function New-SecureStoreSecret {
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNull()]
-        [SecureStoreSecureStringTransformation()]
+        [SecureStoreSecureStringTransformationAttribute()]
         [System.Security.SecureString]$Password,
 
         [Parameter()]


### PR DESCRIPTION
## Summary
- update SecureStore cmdlets to reference the SecureStoreSecureStringTransformation attribute by its full type name
- avoid module import failures caused by unresolved custom attribute types on Windows PowerShell

## Testing
- not run (pwsh is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e007f05218833182f9b73c1cafe2ac