### PR TITLE
Remove dependency on custom attribute for password conversion

### DIFF
--- a/New-SecureStoreCertificate.ps1
+++ b/New-SecureStoreCertificate.ps1
@@ -82,8 +82,7 @@ function New-SecureStoreCertificate {
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNull()]
-        [SecureStoreSecureStringTransformationAttribute()]
-        [System.Security.SecureString]$Password,
+        [object]$Password,
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]

--- a/New-SecureStoreSecret.ps1
+++ b/New-SecureStoreSecret.ps1
@@ -55,8 +55,7 @@ function New-SecureStoreSecret {
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNull()]
-        [SecureStoreSecureStringTransformationAttribute()]
-        [System.Security.SecureString]$Password,
+        [object]$Password,
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]

--- a/tests/SecureStore.Tests.ps1
+++ b/tests/SecureStore.Tests.ps1
@@ -38,10 +38,9 @@ Describe 'SecureStore defaults' {
 }
 
 Describe 'SecureStore secure string helpers' {
-    It 'transforms plain text values using the argument transformation attribute' {
+    It 'converts plain text values into SecureString instances' {
         InModuleScope SecureStore {
-            $attribute = [SecureStoreSecureStringTransformationAttribute]::new()
-            $secure = $attribute.Transform($ExecutionContext, 'topsecret')
+            $secure = ConvertTo-SecureStoreSecureString -InputObject 'topsecret'
             $secure | Should -BeOfType ([System.Security.SecureString])
 
             $bytes = Get-SecureStorePlaintextData -SecureString $secure
@@ -51,8 +50,7 @@ Describe 'SecureStore secure string helpers' {
 
     It 'converts arrays of plain text to secure strings' {
         InModuleScope SecureStore {
-            $attribute = [SecureStoreSecureStringTransformationAttribute]::new()
-            $result = $attribute.Transform($ExecutionContext, @('first', 'second'))
+            $result = ConvertTo-SecureStoreSecureString -InputObject @('first', 'second')
 
             $result | Should -HaveCount 2
             foreach ($entry in $result) {


### PR DESCRIPTION
## Summary
- accept password inputs as objects within the public cmdlets and rely on ConvertTo-SecureStoreSecureString for normalization
- remove the SecureStoreSecureStringTransformationAttribute class and expand ConvertTo-SecureStoreSecureString to handle enumerable inputs
- update the Pester tests to validate the new conversion flow

## Testing
- pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path tests -Output Detailed" *(fails: pwsh not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e00ad8b5a88331bd48ac16948ea077