### PR TITLE
Set Windows default SecureStore path

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ SecureStore selects a platform-specific default base folder. Override anytime wi
 
 | Platform | Default Path |
 |----------|--------------|
-| Windows  | `Join-Path $env:ProgramData 'SecureStore'` |
+| Windows  | `C:\\SecureStore` |
 | Non-Windows | `Join-Path $HOME '.securestore'` |
 
 > **Migration note:** Existing `secret` folders are still accepted but deprecated; migrate to `secrets` soon. Future major versions will remove `secret` support.
@@ -44,7 +44,7 @@ New-SecureStoreCertificate -CertificateName 'WebApp' -Password 'Sup3rPfx!' -DnsN
 Get-SecureStoreList | Format-List
 ```
 
-> **Cross-platform note:** On Windows, SecureStore defaults to `C:\ProgramData\SecureStore`. On Linux and macOS it uses `$HOME/.securestore`. Override with `-FolderPath` to target alternate roots.
+> **Cross-platform note:** On Windows, SecureStore defaults to `C:\SecureStore`. On Linux and macOS it uses `$HOME/.securestore`. Override with `-FolderPath` to target alternate roots.
 
 ## Installation
 

--- a/SecureStore.psm1
+++ b/SecureStore.psm1
@@ -62,12 +62,7 @@ function Get-SecureStoreDefaultPath {
     param()
 
     if ($script:IsWindowsPlatform) {
-        $programData = $env:ProgramData
-        if ([string]::IsNullOrWhiteSpace($programData)) {
-            throw "ProgramData environment variable is not set."
-        }
-
-        return [System.IO.Path]::Combine($programData, 'SecureStore')
+        return 'C:\\SecureStore'
     }
 
     $homePath = if (-not [string]::IsNullOrWhiteSpace($env:HOME)) { $env:HOME } else { $HOME }

--- a/tests/SecureStore.Tests.ps1
+++ b/tests/SecureStore.Tests.ps1
@@ -1,19 +1,15 @@
 Import-Module "$PSScriptRoot/../SecureStore.psd1" -Force
 
 Describe 'SecureStore defaults' {
-    It 'uses ProgramData on Windows platforms' {
+    It 'uses C:\\SecureStore on Windows platforms' {
         InModuleScope SecureStore {
             $originalFlag = $script:IsWindowsPlatform
-            $originalProgramData = $env:ProgramData
             try {
                 $script:IsWindowsPlatform = $true
-                $env:ProgramData = 'C:\\ProgramData'
-                $expected = [System.IO.Path]::Combine('C:\\ProgramData', 'SecureStore')
-                Get-SecureStoreDefaultPath | Should -Be $expected
+                Get-SecureStoreDefaultPath | Should -Be 'C:\\SecureStore'
             }
             finally {
                 $script:IsWindowsPlatform = $originalFlag
-                $env:ProgramData = $originalProgramData
             }
         }
     }


### PR DESCRIPTION
## Summary
- update `Get-SecureStoreDefaultPath` to default to `C:\SecureStore` on Windows
- refresh documentation and unit tests to match the centralized Windows path

## Testing
- `pwsh -NoLogo -Command 'Import-Module ./SecureStore.psd1 -Force; $base = Join-Path (Get-Location) "outstore"; if (Test-Path -LiteralPath $base) { Remove-Item -LiteralPath $base -Recurse -Force; } New-SecureStoreSecret -KeyName "ManualSecret" -SecretFileName "manual.secret" -Password "Sup3r$ecret" -FolderPath $base -Confirm:$false -Verbose'`
- `pwsh -NoLogo -Command 'Import-Module ./SecureStore.psd1 -Force; $base = Join-Path (Get-Location) "outstore"; New-SecureStoreCertificate -CertificateName "ManualCert" -Password "Sup3rPfx!" -DnsName "manual.example.com" -FolderPath $base -ExportPem -Confirm:$false -Verbose'`


------
https://chatgpt.com/codex/tasks/task_e_68e00dfc66f4833196d71def6cf8bbf2