### PR TITLE
Add PEM private key export for certificates

### DIFF
--- a/New-SecureStoreCertificate.ps1
+++ b/New-SecureStoreCertificate.ps1
@@ -72,6 +72,330 @@ PFX export always requires a password. Temporary files are removed once the move
 .LINK
 Get-SecureStoreList
 #>
+
+function ConvertTo-SecureStorePemBlock {
+    param(
+        [Parameter(Mandatory = $true)][ValidateNotNullOrEmpty()][string]$Label,
+        [Parameter(Mandatory = $true)][ValidateNotNull()][byte[]]$Data
+    )
+
+    $base64 = [Convert]::ToBase64String($Data, 'InsertLineBreaks')
+    return "-----BEGIN $Label-----`n$base64`n-----END $Label-----"
+}
+
+function ConvertTo-SecureStoreDerLength {
+    param([Parameter(Mandatory = $true)][ValidateRange(0, [int]::MaxValue)] [int]$Length)
+
+    if ($Length -lt 0x80) {
+        return ,([byte]$Length)
+    }
+
+    $segments = @()
+    $remaining = $Length
+    while ($remaining -gt 0) {
+        $segments = ,([byte]($remaining -band 0xFF)) + $segments
+        $remaining = $remaining -shr 8
+    }
+
+    $result = New-Object byte[] (1 + $segments.Length)
+    $result[0] = [byte](0x80 -bor $segments.Length)
+    for ($i = 0; $i -lt $segments.Length; $i++) {
+        $result[$i + 1] = $segments[$i]
+    }
+
+    return $result
+}
+
+function ConvertTo-SecureStoreDerInteger {
+    param([Parameter(Mandatory = $true)][ValidateNotNull()][byte[]]$Value)
+
+    $normalized = $Value.Clone()
+    $offset = 0
+    while (($offset -lt $normalized.Length - 1) -and ($normalized[$offset] -eq 0)) {
+        $offset++
+    }
+
+    if ($offset -gt 0) {
+        $trimmed = New-Object byte[] ($normalized.Length - $offset)
+        [Array]::Copy($normalized, $offset, $trimmed, 0, $trimmed.Length)
+        $normalized = $trimmed
+    }
+
+    if ($normalized.Length -eq 0) {
+        $normalized = ,([byte]0)
+    }
+    elseif (($normalized[0] -band 0x80) -ne 0) {
+        $prefixed = New-Object byte[] ($normalized.Length + 1)
+        $prefixed[0] = 0
+        [Array]::Copy($normalized, 0, $prefixed, 1, $normalized.Length)
+        $normalized = $prefixed
+    }
+
+    $lengthBytes = ConvertTo-SecureStoreDerLength -Length $normalized.Length
+    $result = New-Object byte[] (1 + $lengthBytes.Length + $normalized.Length)
+    $result[0] = 0x02
+    [Array]::Copy($lengthBytes, 0, $result, 1, $lengthBytes.Length)
+    [Array]::Copy($normalized, 0, $result, 1 + $lengthBytes.Length, $normalized.Length)
+
+    [Array]::Clear($normalized, 0, $normalized.Length)
+    return $result
+}
+
+function ConvertTo-SecureStoreDerOctetString {
+    param([Parameter(Mandatory = $true)][ValidateNotNull()][byte[]]$Value)
+
+    $lengthBytes = ConvertTo-SecureStoreDerLength -Length $Value.Length
+    $result = New-Object byte[] (1 + $lengthBytes.Length + $Value.Length)
+    $result[0] = 0x04
+    [Array]::Copy($lengthBytes, 0, $result, 1, $lengthBytes.Length)
+    [Array]::Copy($Value, 0, $result, 1 + $lengthBytes.Length, $Value.Length)
+    return $result
+}
+
+function ConvertTo-SecureStoreDerBitString {
+    param([Parameter(Mandatory = $true)][ValidateNotNull()][byte[]]$Value)
+
+    $lengthBytes = ConvertTo-SecureStoreDerLength -Length ($Value.Length + 1)
+    $result = New-Object byte[] (1 + $lengthBytes.Length + $Value.Length + 1)
+    $result[0] = 0x03
+    [Array]::Copy($lengthBytes, 0, $result, 1, $lengthBytes.Length)
+    $result[1 + $lengthBytes.Length] = 0x00
+    [Array]::Copy($Value, 0, $result, 2 + $lengthBytes.Length, $Value.Length)
+    return $result
+}
+
+function ConvertTo-SecureStoreDerObjectIdentifier {
+    param([Parameter(Mandatory = $true)][ValidateNotNullOrEmpty()][string]$OidValue)
+
+    $parts = $OidValue.Split('.')
+    if ($parts.Length -lt 2) {
+        throw "Invalid OID value '$OidValue'."
+    }
+
+    $encoded = New-Object System.Collections.Generic.List[byte]
+    $encoded.Add([byte](([int]$parts[0] * 40) + [int]$parts[1])) | Out-Null
+    for ($i = 2; $i -lt $parts.Length; $i++) {
+        $value = [int]$parts[$i]
+        $stack = @()
+        do {
+            $stack = ,([byte]($value -band 0x7F)) + $stack
+            $value = $value -shr 7
+        } while ($value -gt 0)
+
+        for ($j = 0; $j -lt $stack.Length; $j++) {
+            $byteValue = $stack[$j]
+            if ($j -lt $stack.Length - 1) {
+                $byteValue = $byteValue -bor 0x80
+            }
+            $encoded.Add([byte]$byteValue) | Out-Null
+        }
+    }
+
+    $body = $encoded.ToArray()
+    $lengthBytes = ConvertTo-SecureStoreDerLength -Length $body.Length
+    $result = New-Object byte[] (1 + $lengthBytes.Length + $body.Length)
+    $result[0] = 0x06
+    [Array]::Copy($lengthBytes, 0, $result, 1, $lengthBytes.Length)
+    [Array]::Copy($body, 0, $result, 1 + $lengthBytes.Length, $body.Length)
+    return $result
+}
+
+function ConvertTo-SecureStoreDerContextSpecific {
+    param(
+        [Parameter(Mandatory = $true)][ValidateRange(0, 30)][int]$Tag,
+        [Parameter(Mandatory = $true)][ValidateNotNull()][byte[]]$Content
+    )
+
+    $lengthBytes = ConvertTo-SecureStoreDerLength -Length $Content.Length
+    $result = New-Object byte[] (1 + $lengthBytes.Length + $Content.Length)
+    $result[0] = [byte](0xA0 + $Tag)
+    [Array]::Copy($lengthBytes, 0, $result, 1, $lengthBytes.Length)
+    [Array]::Copy($Content, 0, $result, 1 + $lengthBytes.Length, $Content.Length)
+    return $result
+}
+
+function ConvertTo-SecureStoreDerSequence {
+    param([Parameter(Mandatory = $true)][ValidateNotNull()][byte[][]]$Elements)
+
+    $filtered = @($Elements | Where-Object { $_ -ne $null })
+    $totalLength = 0
+    foreach ($element in $filtered) {
+        $totalLength += $element.Length
+    }
+
+    $lengthBytes = ConvertTo-SecureStoreDerLength -Length $totalLength
+    $result = New-Object byte[] (1 + $lengthBytes.Length + $totalLength)
+    $result[0] = 0x30
+    [Array]::Copy($lengthBytes, 0, $result, 1, $lengthBytes.Length)
+    $offset = 1 + $lengthBytes.Length
+    foreach ($element in $filtered) {
+        [Array]::Copy($element, 0, $result, $offset, $element.Length)
+        $offset += $element.Length
+    }
+
+    return $result
+}
+
+function Export-SecureStoreCertificatePrivateKeyPem {
+    param(
+        [Parameter(Mandatory = $true)][ValidateNotNull()][System.Security.Cryptography.X509Certificates.X509Certificate2]$Certificate,
+        [Parameter(Mandatory = $true)][ValidateSet('RSA', 'ECDSA')][string]$Algorithm,
+        [Parameter()][string]$CurveName
+    )
+
+    if (-not $Certificate.HasPrivateKey) {
+        return $null
+    }
+
+    if ($Algorithm -eq 'RSA') {
+        $rsa = [System.Security.Cryptography.X509Certificates.RSACertificateExtensions]::GetRSAPrivateKey($Certificate)
+        if (-not $rsa) { return $null }
+
+        try {
+            $parameters = $rsa.ExportParameters($true)
+        }
+        catch {
+            if ($rsa -is [System.IDisposable]) { $rsa.Dispose() }
+            throw
+        }
+
+        try {
+            $zero = New-Object byte[] 1
+            $version = ConvertTo-SecureStoreDerInteger -Value $zero
+            $modulus = ConvertTo-SecureStoreDerInteger -Value $parameters.Modulus
+            $publicExponent = ConvertTo-SecureStoreDerInteger -Value $parameters.Exponent
+            $privateExponent = ConvertTo-SecureStoreDerInteger -Value $parameters.D
+            $prime1 = ConvertTo-SecureStoreDerInteger -Value $parameters.P
+            $prime2 = ConvertTo-SecureStoreDerInteger -Value $parameters.Q
+            $exponent1 = ConvertTo-SecureStoreDerInteger -Value $parameters.DP
+            $exponent2 = ConvertTo-SecureStoreDerInteger -Value $parameters.DQ
+            $coefficient = ConvertTo-SecureStoreDerInteger -Value $parameters.InverseQ
+
+            $sequence = ConvertTo-SecureStoreDerSequence -Elements @(
+                $version,
+                $modulus,
+                $publicExponent,
+                $privateExponent,
+                $prime1,
+                $prime2,
+                $exponent1,
+                $exponent2,
+                $coefficient
+            )
+
+            $pem = ConvertTo-SecureStorePemBlock -Label 'RSA PRIVATE KEY' -Data $sequence
+            [Array]::Clear($sequence, 0, $sequence.Length)
+            return $pem
+        }
+        finally {
+            if ($parameters.D) { [Array]::Clear($parameters.D, 0, $parameters.D.Length) }
+            if ($parameters.DP) { [Array]::Clear($parameters.DP, 0, $parameters.DP.Length) }
+            if ($parameters.DQ) { [Array]::Clear($parameters.DQ, 0, $parameters.DQ.Length) }
+            if ($parameters.Exponent) { [Array]::Clear($parameters.Exponent, 0, $parameters.Exponent.Length) }
+            if ($parameters.InverseQ) { [Array]::Clear($parameters.InverseQ, 0, $parameters.InverseQ.Length) }
+            if ($parameters.Modulus) { [Array]::Clear($parameters.Modulus, 0, $parameters.Modulus.Length) }
+            if ($parameters.P) { [Array]::Clear($parameters.P, 0, $parameters.P.Length) }
+            if ($parameters.Q) { [Array]::Clear($parameters.Q, 0, $parameters.Q.Length) }
+            if ($rsa -is [System.IDisposable]) { $rsa.Dispose() }
+        }
+    }
+
+    $ecdsa = [System.Security.Cryptography.X509Certificates.ECDsaCertificateExtensions]::GetECDsaPrivateKey($Certificate)
+    if (-not $ecdsa) { return $null }
+
+    try {
+        $parameters = $ecdsa.ExportParameters($true)
+    }
+    catch {
+        if ($ecdsa -is [System.IDisposable]) { $ecdsa.Dispose() }
+        throw
+    }
+
+    try {
+        $versionBytes = New-Object byte[] 1
+        $versionBytes[0] = 1
+        $version = ConvertTo-SecureStoreDerInteger -Value $versionBytes
+
+        $keySize = if ($parameters.D) { $parameters.D.Length } else { 0 }
+        if ($parameters.Q.X -and ($parameters.Q.X.Length -gt $keySize)) {
+            $keySize = $parameters.Q.X.Length
+        }
+        if ($parameters.Q.Y -and ($parameters.Q.Y.Length -gt $keySize)) {
+            $keySize = $parameters.Q.Y.Length
+        }
+
+        $padded = if ($parameters.D) {
+            $buffer = New-Object byte[] $keySize
+            $offset = $keySize - $parameters.D.Length
+            if ($offset -lt 0) { throw 'ECDSA private key length mismatch.' }
+            [Array]::Copy($parameters.D, 0, $buffer, $offset, $parameters.D.Length)
+            $buffer
+        }
+        else {
+            New-Object byte[] 0
+        }
+
+        $privateKey = ConvertTo-SecureStoreDerOctetString -Value $padded
+        if ($padded.Length -gt 0) {
+            [Array]::Clear($padded, 0, $padded.Length)
+        }
+
+        $curveOid = $null
+        if (-not [string]::IsNullOrWhiteSpace($CurveName)) {
+            switch ($CurveName.ToLowerInvariant()) {
+                'nistp256' { $curveOid = '1.2.840.10045.3.1.7' }
+                'nistp384' { $curveOid = '1.3.132.0.34' }
+                'nistp521' { $curveOid = '1.3.132.0.35' }
+            }
+        }
+
+        if (-not $curveOid) {
+            $length = if ($parameters.Q.X) { $parameters.Q.X.Length } else { 0 }
+            switch ($length) {
+                32 { $curveOid = '1.2.840.10045.3.1.7' }
+                48 { $curveOid = '1.3.132.0.34' }
+                66 { $curveOid = '1.3.132.0.35' }
+                default { throw 'Unable to determine ECDSA curve OID.' }
+            }
+        }
+
+        $parametersElement = ConvertTo-SecureStoreDerContextSpecific -Tag 0 -Content (ConvertTo-SecureStoreDerObjectIdentifier -OidValue $curveOid)
+
+        $publicBuffer = if ($parameters.Q.X -and $parameters.Q.Y) {
+            $buffer = New-Object byte[] (1 + $parameters.Q.X.Length + $parameters.Q.Y.Length)
+            $buffer[0] = 0x04
+            [Array]::Copy($parameters.Q.X, 0, $buffer, 1, $parameters.Q.X.Length)
+            [Array]::Copy($parameters.Q.Y, 0, $buffer, 1 + $parameters.Q.X.Length, $parameters.Q.Y.Length)
+            $buffer
+        }
+        else {
+            New-Object byte[] 1
+        }
+
+        $publicKey = ConvertTo-SecureStoreDerContextSpecific -Tag 1 -Content (ConvertTo-SecureStoreDerBitString -Value $publicBuffer)
+        if ($publicBuffer.Length -gt 0) {
+            [Array]::Clear($publicBuffer, 0, $publicBuffer.Length)
+        }
+
+        $sequence = ConvertTo-SecureStoreDerSequence -Elements @(
+            $version,
+            $privateKey,
+            $parametersElement,
+            $publicKey
+        )
+
+        $pem = ConvertTo-SecureStorePemBlock -Label 'EC PRIVATE KEY' -Data $sequence
+        [Array]::Clear($sequence, 0, $sequence.Length)
+        return $pem
+    }
+    finally {
+        if ($parameters.D) { [Array]::Clear($parameters.D, 0, $parameters.D.Length) }
+        if ($parameters.Q.X) { [Array]::Clear($parameters.Q.X, 0, $parameters.Q.X.Length) }
+        if ($parameters.Q.Y) { [Array]::Clear($parameters.Q.Y, 0, $parameters.Q.Y.Length) }
+        if ($ecdsa -is [System.IDisposable]) { $ecdsa.Dispose() }
+    }
+}
+
 function New-SecureStoreCertificate {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
     [OutputType([pscustomobject])]
@@ -314,20 +638,35 @@ function New-SecureStoreCertificate {
                 }
 
                 if ($ExportPem.IsPresent) {
-                    # Export a PEM when requested while ensuring buffers are cleared afterwards.
+                    # Export a PEM containing both the certificate and private key when requested.
+                    $pemSections = @()
                     $certBytes = $certificate.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert)
                     try {
-                        $pemContent = "-----BEGIN CERTIFICATE-----`n" + [Convert]::ToBase64String($certBytes, 'InsertLineBreaks') + "`n-----END CERTIFICATE-----"
-                        $pemBytes = [System.Text.Encoding]::ASCII.GetBytes($pemContent)
-                        try {
-                            Write-SecureStoreFile -Path $pemPath -Bytes $pemBytes
-                        }
-                        finally {
-                            [Array]::Clear($pemBytes, 0, $pemBytes.Length)
-                        }
+                        $pemSections += ConvertTo-SecureStorePemBlock -Label 'CERTIFICATE' -Data $certBytes
                     }
                     finally {
                         [Array]::Clear($certBytes, 0, $certBytes.Length)
+                    }
+
+                    try {
+                        $privateKeyPem = Export-SecureStoreCertificatePrivateKeyPem -Certificate $certificate -Algorithm $Algorithm -CurveName $CurveName
+                        if (-not $privateKeyPem) {
+                            throw [System.InvalidOperationException]::new('Private key export returned no data.')
+                        }
+                        $pemSections += $privateKeyPem
+                    }
+                    catch {
+                        throw [System.InvalidOperationException]::new("Failed to export PEM private key for certificate '$CertificateName'.", $_.Exception)
+                    }
+
+                    $lineBreak = [System.Environment]::NewLine
+                    $pemContent = [string]::Join("$lineBreak$lineBreak", $pemSections)
+                    $pemBytes = [System.Text.Encoding]::ASCII.GetBytes($pemContent + $lineBreak)
+                    try {
+                        Write-SecureStoreFile -Path $pemPath -Bytes $pemBytes
+                    }
+                    finally {
+                        [Array]::Clear($pemBytes, 0, $pemBytes.Length)
                     }
                 }
             }

--- a/tests/SecureStore.Tests.ps1
+++ b/tests/SecureStore.Tests.ps1
@@ -349,6 +349,9 @@ Describe 'New-SecureStoreCertificate' {
             $result.CertificateName | Should -Be 'WebApp'
             $script:MockFiles.Keys | Should -Contain '/securestore/certs/WebApp.pfx'
             $script:MockFiles.Keys | Should -Contain '/securestore/certs/WebApp.pem'
+            $pemContent = [System.Text.Encoding]::ASCII.GetString($script:MockFiles['/securestore/certs/WebApp.pem'])
+            $pemContent | Should -Match 'BEGIN CERTIFICATE'
+            $pemContent | Should -Match 'BEGIN RSA PRIVATE KEY'
         }
     }
 
@@ -359,6 +362,16 @@ Describe 'New-SecureStoreCertificate' {
             $secure.MakeReadOnly()
             New-SecureStoreCertificate -CertificateName 'Api' -Password $secure -Algorithm ECDSA -CurveName nistP256 -ValidityYears 2 -Confirm:$false
             $script:MockFiles.Keys | Should -Contain '/securestore/certs/Api.pfx'
+        }
+    }
+
+    It 'exports PEM including EC private key for ECDSA certificates' {
+        InModuleScope SecureStore {
+            $result = New-SecureStoreCertificate -CertificateName 'Ecc' -Password 'Sup3rPfx!' -Algorithm ECDSA -CurveName nistP256 -ExportPem -Confirm:$false
+            $result.Paths.Pem | Should -Be '/securestore/certs/Ecc.pem'
+            $pemContent = [System.Text.Encoding]::ASCII.GetString($script:MockFiles['/securestore/certs/Ecc.pem'])
+            $pemContent | Should -Match 'BEGIN CERTIFICATE'
+            $pemContent | Should -Match 'BEGIN EC PRIVATE KEY'
         }
     }
 


### PR DESCRIPTION
## Summary
- add helper routines that serialise RSA and ECDSA private keys into PEM blocks
- update New-SecureStoreCertificate to emit certificate and private key data whenever -ExportPem is used
- extend the test suite to validate the new PEM content for both RSA and ECDSA certificates

## Testing
- not run (PowerShell unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e01f33966c83318dbed8b85b949248