### PR TITLE
Add PFX certificate support and adjust secret parameters

### DIFF
--- a/Get-SecureStoreList.ps1
+++ b/Get-SecureStoreList.ps1
@@ -95,6 +95,14 @@ function Get-SecureStoreList {
           '.cer' { $certificate = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($file.FullName) }
           '.crt' { $certificate = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($file.FullName) }
           '.der' { $certificate = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($file.FullName) }
+          '.pfx' {
+            try {
+              $certificate = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($file.FullName)
+            }
+            catch {
+              Write-Verbose "Failed to load PFX certificate '$($file.FullName)': $($_.Exception.Message)"
+            }
+          }
           default { }
         }
 

--- a/New-SecureStoreSecret.ps1
+++ b/New-SecureStoreSecret.ps1
@@ -60,6 +60,10 @@ function New-SecureStoreSecret {
   [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium', DefaultParameterSetName = 'ByKey')]
   param(
     [Parameter(ParameterSetName = 'ByKey', Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$KeyName,
+
+    [Parameter(ParameterSetName = 'ByKey', Mandatory = $true)]
     [Parameter(ParameterSetName = 'ByCertThumbprint', Mandatory = $true)]
     [Parameter(ParameterSetName = 'ByCertPath', Mandatory = $true)]
     [ValidateNotNullOrEmpty()]


### PR DESCRIPTION
## Summary
- add the missing KeyName parameter to the AES parameter set so SecretFileName can be required for all scenarios
- extend certificate enumeration to attempt loading .pfx files and surface verbose diagnostics when parsing fails

## Testing
- powershell -NoLogo -NoProfile -Command "Invoke-Pester -Path tests/Test-SecureStoreComplete.ps1" *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e1bda6f0ac833183616252655edb38