### PR TITLE
Fix certificate encryption flows

### DIFF
--- a/Get-SecureStoreList.ps1
+++ b/Get-SecureStoreList.ps1
@@ -101,6 +101,15 @@ function Get-SecureStoreList {
             }
             catch {
               Write-Verbose "Failed to load PFX certificate '$($file.FullName)': $($_.Exception.Message)"
+              $cerPath = [System.IO.Path]::ChangeExtension($file.FullName, '.cer')
+              if (Test-Path -LiteralPath $cerPath) {
+                try {
+                  $certificate = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($cerPath)
+                }
+                catch {
+                  Write-Verbose "Failed to load companion CER certificate '$cerPath': $($_.Exception.Message)"
+                }
+              }
             }
           }
           default { }


### PR DESCRIPTION
## Summary
- use the shared certificate helper in `New-SecureStoreSecret` and surface friendly errors when certificate encryption fails
- keep generated certificates in the store, export a companion `.cer`, and return the new path from `New-SecureStoreCertificate`
- allow `Get-SecureStoreList` to read metadata from `.cer` fallbacks so certificate listings include thumbprints and expiry warnings

## Testing
- `pwsh -NoLogo -Command "Import-Module Pester -ErrorAction Stop; Invoke-Pester"`


------
https://chatgpt.com/codex/tasks/task_e_68e1c5c788f883318c1f020db4dc4ad0