### PR TITLE
Improve certificate padding fallback and secret error handling

### DIFF
--- a/New-SecureStoreSecret.ps1
+++ b/New-SecureStoreSecret.ps1
@@ -148,7 +148,15 @@ function New-SecureStoreSecret {
         # Encrypt plaintext with AES and write JSON payload
         try {
           $plaintextBytes = Get-SecureStorePlaintextData -SecureString $securePassword
-          $payloadJson = Protect-SecureStoreSecret -Plaintext $plaintextBytes -MasterKey $encryptionKey
+          try {
+            $payloadJson = Protect-SecureStoreSecret -Plaintext $plaintextBytes -MasterKey $encryptionKey
+          }
+          catch {
+            throw [System.InvalidOperationException]::new(
+              "Failed to create or update secret '$SecretFileName': $($_.Exception.Message)",
+              $_.Exception
+            )
+          }
           $payloadBytes = [System.Text.Encoding]::UTF8.GetBytes($payloadJson)
           try {
             Write-SecureStoreFile -Path $secretFilePath -Bytes $payloadBytes


### PR DESCRIPTION
## Summary
- add OAEP-SHA256/OAEP-SHA1 fallback logic when encrypting secrets with certificates and persist the padding choice in the payload
- mirror the padding detection during certificate decryption to keep PS5.1 compatibility
- wrap secret creation encryption calls to surface friendly InvalidOperationException messages

## Testing
- pwsh -NoLogo -NoProfile -Command "Invoke-ScriptAnalyzer -Path . -Recurse"
- pwsh -NoLogo -NoProfile -File tests/Test-SecureStoreComplete.ps1 -TestPath /workspace/SecureStoreTest


------
https://chatgpt.com/codex/tasks/task_e_68e1d5c07c0483319aad29eca783d523