### PR TITLE
Fix certificate secret decryption and auto-detection

### DIFF
--- a/Get-SecureStoreList.ps1
+++ b/Get-SecureStoreList.ps1
@@ -97,14 +97,18 @@ function Get-SecureStoreList {
           '.der' { $certificate = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($file.FullName) }
           '.pfx' {
             try {
-              $certificate = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($file.FullName)
+              $certificate = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new(
+                $file.FullName,
+                [string]::Empty,
+                [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable
+              )
             }
             catch {
               Write-Verbose "Failed to load PFX certificate '$($file.FullName)': $($_.Exception.Message)"
               $cerPath = [System.IO.Path]::ChangeExtension($file.FullName, '.cer')
               if (Test-Path -LiteralPath $cerPath) {
                 try {
-                  $certificate = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($cerPath)
+                  $certificate = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($cerPath)
                 }
                 catch {
                   Write-Verbose "Failed to load companion CER certificate '$cerPath': $($_.Exception.Message)"


### PR DESCRIPTION
## Summary
- add a decryption helper and metadata support so certificate payloads record padding and file hints
- harden Get-SecureStoreSecret to locate store or file certificates automatically and emit clearer errors without leaking secret names
- update inventory listing to parse passwordless PFX files before falling back to companion CER exports

## Testing
- pwsh -NoLogo -NoProfile -File tests/Test-SecureStoreComplete.ps1 -TestPath /workspace/SecureStore/TestRun -SkipCleanup

------
https://chatgpt.com/codex/tasks/task_e_68e1dc01b7308331b0b030f6d6bd710f