### PR TITLE
Fix certificate decryption and improve secret retrieval

### DIFF
--- a/SecureStore.psd1
+++ b/SecureStore.psd1
@@ -54,7 +54,7 @@
       Tags                       = @('Security', 'Secrets', 'Certificates', 'Encryption', 'LocalStorage', 'AES', 'PKI')
 
       # Release notes for this module
-      ReleaseNotes               = 'Version 2.0.0: Centralized storage, standardized folder structure, integrated certificate generation'
+      ReleaseNotes               = 'Version 2.0.1: Restored certificate decryption with padding fallback, automatic certificate discovery, and seamless v2/v3 secret retrieval'
 
       # Prerelease string for this module
       Prerelease                 = ''


### PR DESCRIPTION
## Summary
- add RSA padding fallback and secure buffer disposal to `Unprotect-SecureStoreSecretWithCertificate`
- teach `Get-SecureStoreSecret` to auto-detect certificates, honor version 2/3 payloads, and surface friendlier errors
- refresh the module release notes to document the certificate decryption fixes

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-ScriptAnalyzer -Path ."`
- `pwsh -NoLogo -NoProfile -Command '$env:PSModulePath = (Split-Path (Get-Location).Path -Parent) + [System.IO.Path]::PathSeparator + $env:PSModulePath; & "tests/Test-SecureStoreComplete.ps1" -TestPath (Join-Path (Get-Location).Path "TestSecureStore")'`

------
https://chatgpt.com/codex/tasks/task_e_68e1e072fbf0833189043f9e542cbec7