### PR TITLE
Default certificates include client authentication EKU

### DIFF
--- a/New-SecureStoreCertificate.ps1
+++ b/New-SecureStoreCertificate.ps1
@@ -44,7 +44,7 @@ Optional email subject alternative names.
 Optional URI subject alternative names.
 
 .PARAMETER EnhancedKeyUsage
-Optional EKU list to embed within the certificate.
+Optional EKU list to embed within the certificate. Defaults include both Server and Client Authentication.
 
 .PARAMETER ExportPem
 Switch to export a PEM copy alongside the PFX.
@@ -251,7 +251,7 @@ function New-SecureStoreCertificate {
     [string[]]$Uri,
 
     [Parameter()]
-    [string[]]$EnhancedKeyUsage = @('1.3.6.1.5.5.7.3.1'),
+    [string[]]$EnhancedKeyUsage = @('1.3.6.1.5.5.7.3.1', '1.3.6.1.5.5.7.3.2'),
 
     [Parameter(ParameterSetName = 'Export')]
     [switch]$ExportPem,

--- a/README.md
+++ b/README.md
@@ -153,12 +153,11 @@ New-SecureStoreCertificate -CertificateName 'MyAppCert' -Password 'CertPass123' 
 $secure = Read-Host 'PFX password' -AsSecureString
 New-SecureStoreCertificate -CertificateName 'Api' -Password $secure -Algorithm ECDSA -CurveName nistP256 -ValidityYears 2 -ExportPem
 
-# Advanced RSA certificate with SAN and EKU
+# Advanced RSA certificate with SAN and EKU (Server + Client auth by default)
 New-SecureStoreCertificate -CertificateName 'WebServer' -Password 'Pass123' `
     -Algorithm RSA -KeyLength 4096 `
     -DnsName 'web.local', '*.web.local' `
     -IpAddress '10.0.1.100' `
-    -EnhancedKeyUsage '1.3.6.1.5.5.7.3.1' `
     -ValidityYears 5 `
     -ExportPem
 
@@ -167,6 +166,8 @@ New-SecureStoreCertificate -CertificateName 'UserAuth' -Password 'AuthPass123' `
     -EnhancedKeyUsage '1.3.6.1.5.5.7.3.2' `
     -StoreOnly
 ```
+
+> **Note:** By default, certificates are issued with both Server (`1.3.6.1.5.5.7.3.1`) and Client (`1.3.6.1.5.5.7.3.2`) authentication EKUs, ensuring compatibility with Entra ID / Microsoft Graph application registrations.
 
 #### Certificate Parameters
 
@@ -184,7 +185,7 @@ New-SecureStoreCertificate -CertificateName 'UserAuth' -Password 'AuthPass123' `
 | `IpAddress` | String[] | (None) | IP subject alternative names |
 | `Email` | String[] | (None) | Email subject alternative names |
 | `Uri` | String[] | (None) | URI subject alternative names |
-| `EnhancedKeyUsage` | String[] | `1.3.6.1.5.5.7.3.1` | EKU OIDs (Server Authentication by default) |
+| `EnhancedKeyUsage` | String[] | `1.3.6.1.5.5.7.3.1`, `1.3.6.1.5.5.7.3.2` | EKU OIDs (Server + Client Authentication by default) |
 | `ExportPem` | Switch | `$false` | Export PEM file alongside PFX |
 | `StoreOnly` | Switch | `$false` | Keep in cert store without exporting files |
 


### PR DESCRIPTION
## Summary
- update New-SecureStoreCertificate so default certificates include both server and client authentication EKUs for Entra ID compatibility
- document the new default EKU behavior and compatibility note in the README

## Testing
- Not run (pwsh not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f2ca71e9f08331a6359c5a2550bf0e